### PR TITLE
feat: configurable projection types

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -86,9 +86,13 @@ akka {
 }
 
 event-processor {
-  # tags per projection
+  # Type of projection: at-least-once, exactly-once, grouped, logging-only
+  projection-type = at-least-once
+
+  # Number of tags or slice ranges per projection
   # Increase for realisitc testing
   parallelism = 8
+
   # how many projections to run. Each will do the same thing
   # and the end result is validated for all
   # each projectin uses its own set of tags to increase load on the tag_* tables as it is better if those

--- a/src/main/scala/akka/projection/testing/EventProcessorSettings.scala
+++ b/src/main/scala/akka/projection/testing/EventProcessorSettings.scala
@@ -5,24 +5,50 @@
 package akka.projection.testing
 
 import akka.actor.typed.ActorSystem
+import akka.projection.testing.EventProcessorSettings.ProjectionType
+import akka.util.Helpers.toRootLowerCase
 import com.typesafe.config.Config
 
 object EventProcessorSettings {
+
+  sealed trait ProjectionType
+
+  object ProjectionType {
+    def apply(typeName: String): ProjectionType = {
+      toRootLowerCase(typeName) match {
+        case "at-least-once" => AtLeastOnce
+        case "exactly-once"  => ExactlyOnce
+        case "grouped"       => Grouped
+        case "logging-only"  => LoggingOnly
+      }
+    }
+
+    case object AtLeastOnce extends ProjectionType
+    case object ExactlyOnce extends ProjectionType
+    case object Grouped extends ProjectionType
+    case object LoggingOnly extends ProjectionType
+  }
 
   def apply(system: ActorSystem[_]): EventProcessorSettings = {
     apply(system.settings.config.getConfig("event-processor"))
   }
 
   def apply(config: Config): EventProcessorSettings = {
+    val projectionType = ProjectionType(config.getString("projection-type"))
     val parallelism: Int = config.getInt("parallelism")
     val nrProjections: Int = config.getInt("nr-projections")
-    val readOny = config.getBoolean("read-only")
+    val readOnly = config.getBoolean("read-only")
     val failEvery = config.getString("projection-failure-every").toLowerCase() match {
       case "off" => Int.MaxValue
       case _     => config.getInt("projection-failure-every")
     }
-    EventProcessorSettings(parallelism, nrProjections, readOny, failEvery)
+    EventProcessorSettings(projectionType, parallelism, nrProjections, readOnly, failEvery)
   }
 }
 
-final case class EventProcessorSettings(parallelism: Int, nrProjections: Int, readOnly: Boolean, failEvery: Int)
+final case class EventProcessorSettings(
+    projectionType: ProjectionType,
+    parallelism: Int,
+    nrProjections: Int,
+    readOnly: Boolean,
+    failEvery: Int)

--- a/src/main/scala/akka/projection/testing/TestProjectionHandler.scala
+++ b/src/main/scala/akka/projection/testing/TestProjectionHandler.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing
+
+import java.util.concurrent.ThreadLocalRandom.{ current => random }
+
+import scala.util.control.NoStackTrace
+
+import akka.persistence.query.Offset
+import akka.projection.ProjectionId
+import org.slf4j.LoggerFactory
+
+trait EnvelopeAccess[Envelope[_]] {
+  def event[Event](envelope: Envelope[Event]): Event
+  def offset(envelope: Envelope[_]): Offset
+  def persistenceId(envelope: Envelope[_]): String
+  def sequenceNr(envelope: Envelope[_]): Long
+}
+
+object EnvelopeAccess {
+  implicit object TestEventEnvelope extends EnvelopeAccess[akka.projection.eventsourced.EventEnvelope] {
+    def event[Event](envelope: akka.projection.eventsourced.EventEnvelope[Event]): Event = envelope.event
+    def offset(envelope: akka.projection.eventsourced.EventEnvelope[_]): Offset = envelope.offset
+    def persistenceId(envelope: akka.projection.eventsourced.EventEnvelope[_]): String = envelope.persistenceId
+    def sequenceNr(envelope: akka.projection.eventsourced.EventEnvelope[_]): Long = envelope.sequenceNr
+  }
+
+  implicit object TestTypedEventEnvelope extends EnvelopeAccess[akka.persistence.query.typed.EventEnvelope] {
+    def event[Event](envelope: akka.persistence.query.typed.EventEnvelope[Event]): Event = envelope.event
+    def offset(envelope: akka.persistence.query.typed.EventEnvelope[_]): Offset = envelope.offset
+    def persistenceId(envelope: akka.persistence.query.typed.EventEnvelope[_]): String = envelope.persistenceId
+    def sequenceNr(envelope: akka.persistence.query.typed.EventEnvelope[_]): Long = envelope.sequenceNr
+  }
+}
+
+trait TestProjectionHandler[Envelope[_]] {
+  def projectionId: ProjectionId
+  def failEvery: Int
+
+  private val log = LoggerFactory.getLogger(getClass)
+  private var startTime = System.nanoTime()
+  private var count = 0
+
+  def testProcessing(envelope: Envelope[ConfigurablePersistentActor.Event])(implicit
+      access: EnvelopeAccess[Envelope]): Unit = {
+
+    log.trace(
+      "Projection [{}] processing event [{}] with offset [{}] for test [{}]",
+      projectionId.id,
+      access.event(envelope).payload,
+      access.offset(envelope),
+      access.event(envelope).testName)
+
+    if (failEvery != Int.MaxValue && random.nextInt(failEvery) == 1) {
+      throw new RuntimeException(
+        s"Simulated failure when processing persistence id [${access.persistenceId(envelope)}]," +
+          s" sequence nr [${access.sequenceNr(envelope)}], offset [${access.offset(envelope)}]") with NoStackTrace
+    }
+
+    count += 1
+    if (count == 1000) {
+      val durationMs = (System.nanoTime() - startTime) / 1000 / 1000
+      log.info(
+        "Projection [{}] throughput [{}] events/s in [{}] ms",
+        projectionId.id,
+        1000 * count / durationMs,
+        durationMs)
+      count = 0
+      startTime = System.nanoTime()
+    }
+  }
+
+  def testProcessingGroup(envelopes: Seq[Envelope[ConfigurablePersistentActor.Event]])(implicit
+      access: EnvelopeAccess[Envelope]): Unit = {
+    log.trace(
+      "Projection [{}] processing group of [{}] events for test [{}]",
+      projectionId.id,
+      envelopes.size,
+      envelopes.headOption.map(envelope => access.event(envelope).testName).getOrElse("<unknown>"))
+
+    envelopes.foreach(testProcessing)
+  }
+}

--- a/src/main/scala/akka/projection/testing/dynamodb/DynamoDBProjectionHandler.scala
+++ b/src/main/scala/akka/projection/testing/dynamodb/DynamoDBProjectionHandler.scala
@@ -8,8 +8,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.jdk.CollectionConverters._
-import scala.util.Random
-import scala.util.control.NoStackTrace
+import scala.jdk.FutureConverters._
 
 import akka.Done
 import akka.actor.typed.ActorSystem
@@ -19,50 +18,63 @@ import akka.projection.dynamodb.scaladsl.DynamoDBTransactHandler
 import akka.projection.dynamodb.scaladsl.Requests
 import akka.projection.scaladsl.Handler
 import akka.projection.testing.ConfigurablePersistentActor
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import akka.projection.testing.TestProjectionHandler
 import software.amazon.awssdk.services.dynamodb.DynamoDbAsyncClient
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemRequest
 import software.amazon.awssdk.services.dynamodb.model.Put
+import software.amazon.awssdk.services.dynamodb.model.PutItemRequest
 import software.amazon.awssdk.services.dynamodb.model.PutRequest
 import software.amazon.awssdk.services.dynamodb.model.TransactWriteItem
 import software.amazon.awssdk.services.dynamodb.model.WriteRequest
 
-class DynamoDBProjectionHandler(projectionId: ProjectionId, projectionIndex: Int, readOnly: Boolean, failEvery: Int)
-    extends DynamoDBTransactHandler[EventEnvelope[ConfigurablePersistentActor.Event]] {
+class DynamoDBAtLeastOnceProjectionHandler(
+    val projectionId: ProjectionId,
+    projectionIndex: Int,
+    readOnly: Boolean,
+    val failEvery: Int,
+    client: DynamoDbAsyncClient)
+    extends Handler[EventEnvelope[ConfigurablePersistentActor.Event]]
+    with TestProjectionHandler[EventEnvelope] {
 
   import DynamoDBTables.Events
 
-  private val log: Logger = LoggerFactory.getLogger(getClass)
-  private var startTime = System.nanoTime()
-  private var count = 0
+  override def process(envelope: EventEnvelope[ConfigurablePersistentActor.Event]): Future[Done] = {
+    testProcessing(envelope)
+
+    if (readOnly)
+      Future.successful(Done)
+    else {
+      val attributes = Map(
+        Events.Attributes.Id -> AttributeValue.fromS(s"${envelope.event.testName}-$projectionIndex"),
+        Events.Attributes.Event -> AttributeValue.fromS(envelope.event.payload)).asJava
+
+      val request = PutItemRequest.builder
+        .tableName(Events.TableName)
+        .item(attributes)
+        .build()
+
+      client
+        .putItem(request)
+        .asScala
+        .map(_ => Done)(ExecutionContext.parasitic)
+    }
+  }
+}
+
+class DynamoDBExactlyOnceProjectionHandler(
+    val projectionId: ProjectionId,
+    projectionIndex: Int,
+    readOnly: Boolean,
+    val failEvery: Int)
+    extends DynamoDBTransactHandler[EventEnvelope[ConfigurablePersistentActor.Event]]
+    with TestProjectionHandler[EventEnvelope] {
+
+  import DynamoDBTables.Events
 
   override def process(
       envelope: EventEnvelope[ConfigurablePersistentActor.Event]): Future[Iterable[TransactWriteItem]] = {
-    log.trace(
-      "Projection [{}] processing event [{}] with offset [{}]",
-      projectionId.id,
-      envelope.event.payload,
-      envelope.offset)
-
-    if (failEvery != Int.MaxValue && Random.nextInt(failEvery) == 1) {
-      throw new RuntimeException(
-        s"Simulated failure when processing persistence id [${envelope.persistenceId}]," +
-          s" sequence nr [${envelope.sequenceNr}], offset [${envelope.offset}]") with NoStackTrace
-    }
-
-    count += 1
-    if (count == 1000) {
-      val durationMs = (System.nanoTime() - startTime) / 1000 / 1000
-      log.info(
-        "Projection [{}] throughput [{}] events/s in [{}] ms",
-        projectionId.id,
-        1000 * count / durationMs,
-        durationMs)
-      count = 0
-      startTime = System.nanoTime()
-    }
+    testProcessing(envelope)
 
     if (readOnly)
       Future.successful(Nil)
@@ -87,41 +99,18 @@ class DynamoDBProjectionHandler(projectionId: ProjectionId, projectionIndex: Int
 // when using this consider reducing failure otherwise a high chance of at least one grouped envelope
 // causing an error and no progress will be made
 class DynamoDBGroupedProjectionHandler(
-    projectionId: ProjectionId,
+    val projectionId: ProjectionId,
     projectionIndex: Int,
     readOnly: Boolean,
-    failEvery: Int,
+    val failEvery: Int,
     client: DynamoDbAsyncClient)(implicit system: ActorSystem[_])
-    extends Handler[Seq[EventEnvelope[ConfigurablePersistentActor.Event]]] {
+    extends Handler[Seq[EventEnvelope[ConfigurablePersistentActor.Event]]]
+    with TestProjectionHandler[EventEnvelope] {
 
   import DynamoDBTables.Events
 
-  private val log: Logger = LoggerFactory.getLogger(getClass)
-  private var startTime = System.nanoTime()
-  private var count = 0
-
   override def process(envelopes: Seq[EventEnvelope[ConfigurablePersistentActor.Event]]): Future[Done] = {
-    log.trace("Projection [{}] processing group of [{}] events", projectionId.id, envelopes.size)
-
-    envelopes.foreach { envelope =>
-      if (failEvery != Int.MaxValue && Random.nextInt(failEvery) == 1) {
-        throw new RuntimeException(
-          s"Simulated failure when processing persistence id [${envelope.persistenceId}]," +
-            s" sequence nr [${envelope.sequenceNr}], offset [${envelope.offset}]") with NoStackTrace
-      }
-    }
-
-    count += envelopes.size
-    if (count >= 1000) {
-      val durationMs = (System.nanoTime() - startTime) / 1000 / 1000
-      log.info(
-        "Projection [{}] throughput [{}] events/s in [{}] ms",
-        projectionId.id,
-        1000 * count / durationMs,
-        durationMs)
-      count = 0
-      startTime = System.nanoTime()
-    }
+    testProcessingGroup(envelopes)
 
     if (readOnly)
       Future.successful(Done)

--- a/src/main/scala/akka/projection/testing/jdbc/JdbcProjectionHandler.scala
+++ b/src/main/scala/akka/projection/testing/jdbc/JdbcProjectionHandler.scala
@@ -4,54 +4,20 @@
 
 package akka.projection.testing.jdbc
 
-import scala.util.Random
 import scala.util.Try
-import scala.util.control.NoStackTrace
 
-import akka.actor.typed.ActorSystem
 import akka.projection.ProjectionId
 import akka.projection.eventsourced.EventEnvelope
 import akka.projection.jdbc.scaladsl.JdbcHandler
 import akka.projection.testing.ConfigurablePersistentActor
-import org.slf4j.Logger
-import org.slf4j.LoggerFactory
+import akka.projection.testing.TestProjectionHandler
 
-class JdbcProjectionHandler(
-    projectionId: ProjectionId,
-    projectionIndex: Int,
-    system: ActorSystem[_],
-    readOnly: Boolean,
-    failEvery: Int)
-    extends JdbcHandler[EventEnvelope[ConfigurablePersistentActor.Event], HikariJdbcSession] {
-  private val log: Logger = LoggerFactory.getLogger(getClass)
-  private var startTime = System.nanoTime()
-  private var count = 0
+class JdbcProjectionHandler(val projectionId: ProjectionId, projectionIndex: Int, readOnly: Boolean, val failEvery: Int)
+    extends JdbcHandler[EventEnvelope[ConfigurablePersistentActor.Event], HikariJdbcSession]
+    with TestProjectionHandler[EventEnvelope] {
 
   override def process(session: HikariJdbcSession, envelope: EventEnvelope[ConfigurablePersistentActor.Event]): Unit = {
-    log.trace(
-      "Event {} for projection {} sequence {} test {}",
-      envelope.event.payload,
-      projectionId.id,
-      envelope.offset,
-      envelope.event.testName)
-
-    if (failEvery != Int.MaxValue && Random.nextInt(failEvery) == 1) {
-      throw new RuntimeException(
-        s"Simulated failure when processing persistence id ${envelope.persistenceId} sequence nr ${envelope.sequenceNr} offset ${envelope.offset}")
-        with NoStackTrace
-    }
-
-    count += 1
-    if (count == 1000) {
-      val durationMs = (System.nanoTime() - startTime) / 1000 / 1000
-      log.info(
-        "Projection [{}] throughput [{}] events/s in [{}] ms",
-        projectionId.id,
-        1000 * count / durationMs,
-        durationMs)
-      count = 0
-      startTime = System.nanoTime()
-    }
+    testProcessing(envelope)
 
     if (!readOnly) {
       session.withConnection { connection =>
@@ -70,30 +36,17 @@ class JdbcProjectionHandler(
 // when using this consider reducing failure otherwise a high change of at least one grouped envelope causing an error
 // and no progress will be made
 class JdbcGroupedProjectionHandler(
-    projectionId: ProjectionId,
+    val projectionId: ProjectionId,
     projectionIndex: Int,
-    system: ActorSystem[_],
     readOnly: Boolean,
-    failEvery: Int)
-    extends JdbcHandler[Seq[EventEnvelope[ConfigurablePersistentActor.Event]], HikariJdbcSession] {
-  private val log: Logger = LoggerFactory.getLogger(getClass)
+    val failEvery: Int)
+    extends JdbcHandler[Seq[EventEnvelope[ConfigurablePersistentActor.Event]], HikariJdbcSession]
+    with TestProjectionHandler[EventEnvelope] {
 
   override def process(
       session: HikariJdbcSession,
       envelopes: Seq[EventEnvelope[ConfigurablePersistentActor.Event]]): Unit = {
-    log.trace(
-      "Persisting {} events for projection {} for test {}",
-      envelopes.size,
-      projectionId.id,
-      envelopes.headOption.map(_.event.testName).getOrElse("<unknown>"))
-
-    envelopes.foreach { envelope =>
-      if (failEvery != Int.MaxValue && Random.nextInt(failEvery) == 1) {
-        throw new RuntimeException(
-          s"Simulated failure when processing persistence id ${envelope.persistenceId} sequence nr ${envelope.sequenceNr} offset ${envelope.offset}")
-          with NoStackTrace
-      }
-    }
+    testProcessingGroup(envelopes)
 
     if (!readOnly) {
       session.withConnection { connection =>


### PR DESCRIPTION
Make the projection types configurable, with at-least-once, exactly-once, grouped, or logging-only.

Also move common duplicated code across the handlers (for failures, trace logging, and logging throughput) to one place.