### PR TITLE
feat: add simulation engine

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,7 @@
+OrganizeImports {
+  groups = [
+    "re:javax?\\."
+    "scala."
+    "*"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project tests event sourced actors events that are then read by a projectio
 It is currently support the following alternative Akka Persistence and Akka Projection setup:
 
 * R2DBC (Postgres) as the event sourcing event store and the projection using R2DBC (Postgres)
-* Cassandra as the event sourcing event store and the projection using JDBC (Postgres) 
+* Cassandra as the event sourcing event store and the projection using JDBC (Postgres)
 * JDBC (Postgres) as the event sourcing event store and the projection using JDBC (Postgres)
 
 ## Running a test locally
@@ -48,12 +48,16 @@ Start the application:
 sbt "run 2551"
 ```
 
+### Run simulations
+
+See [simulation/README.md] for more detail on running simulations. Or for simple test runs, see below.
+
 ### Start test run
 
 Start a test run:
 
 ```shell
-curl -X POST --data '{"name":"","nrActors":1000, "messagesPerActor": 100, "concurrentActors": 100, "bytesPerEvent": 100, "timeout": 60000}' --header "content-type: application/json" http://127.0.0.1:8051/test
+curl -X POST --data '{"nrActors":1000, "messagesPerActor": 100, "concurrentActors": 100, "bytesPerEvent": 100, "timeout": 60000}' --header "content-type: application/json" http://127.0.0.1:8051/test
 ```
 
 the params are:
@@ -73,7 +77,7 @@ the expected event total is the `nrActors` * `messagesPeractor` * `${event-proce
 Multiple projections can be run to increase the load on the tagging infrastructure while not overloading the normal event log.
 Each projection gets its own tag for the same reason. A real production application would have different projections use the same tag.
 
-The test checks that every message makes it into the projection. these are stored in the `events` table. Duplicated 
+The test checks that every message makes it into the projection. these are stored in the `events` table. Duplicated
 are detected with a primary key.
 
 To inspect the database:
@@ -137,7 +141,7 @@ Typically, multiple nodes are required to re-create issues as while one node is 
 
 ### cinnamon
 
-the application exposes persistence metrics via cinnamon and prometheus. the cinnamon prometheus sandbox can be used to 
+the application exposes persistence metrics via cinnamon and prometheus. the cinnamon prometheus sandbox can be used to
 view the metrics in grafana.
 
 ## failure scenarios
@@ -145,7 +149,7 @@ view the metrics in grafana.
 ### projection restart
 
 A known edge case is that a projection is restarted and delayed events from before the offset are then missed.
-This should only happen in when multiple nodes are writing events as delayed event should still be written in offset 
+This should only happen in when multiple nodes are writing events as delayed event should still be written in offset
 order.
 
 ## Deployment to eks/gke
@@ -176,7 +180,7 @@ this will create:
 - install the metrics server into the eks cluster (requried by the operator)
 - configure security groups to allow communication
 
-the outputs printed at the end of `terraform apply` give all the information needed to configure the `kubernetes/deployment.yaml` 
+the outputs printed at the end of `terraform apply` give all the information needed to configure the `kubernetes/deployment.yaml`
 
 ```
 db_endpoint = "projection-testing.cgrtpi2lqrw8.us-east-2.rds.amazonaws.com:5432"

--- a/docker/r2dbc/postgres/initdb/create_tables.sql
+++ b/docker/r2dbc/postgres/initdb/create_tables.sql
@@ -1,13 +1,14 @@
-create table if not exists events (
-  name varchar(256),
+CREATE TABLE IF NOT EXISTS events (
+  name VARCHAR(256),
   projection_id BIGINT,
-  event varchar(256),
-  constraint pkey primary key (name, projection_id, event)
+  event VARCHAR(256),
+  updates INTEGER DEFAULT 1,
+  CONSTRAINT pkey PRIMARY KEY (name, projection_id, event)
 );
 
-create table if not exists results (
-  name varchar(256) primary key,
-  result varchar(256)
+CREATE TABLE IF NOT EXISTS results (
+  name VARCHAR(256) PRIMARY KEY,
+  result VARCHAR(256)
 );
 
 CREATE TABLE IF NOT EXISTS event_journal(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.21.2")
+addSbtPlugin("com.lightbend.cinnamon" % "sbt-cinnamon" % "2.21.3-20250408-0269a7e")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.10.4")

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -1,0 +1,17 @@
+# Simulation
+
+A simulation engine can be used to generate more randomised projection tests.
+
+See [../README.md] for more detail on running the projection testing application generally.
+
+Examples for simulation definitions can be found in [examples].
+
+A JSON schema is available in [schema/run-simulation.json].
+
+With the projection testing application running locally with a database, a simple simulation can be run with:
+
+```sh
+curl -X POST http://localhost:8051/simulation/run \
+     -H "Content-Type: application/json" \
+     -d @simulation/examples/simple.json
+```

--- a/simulation/dynamodb/eks/dynamodb-policy.json
+++ b/simulation/dynamodb/eks/dynamodb-policy.json
@@ -1,0 +1,24 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:BatchGetItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:DescribeTable",
+        "dynamodb:DescribeTimeToLive"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:*:*:table/*",
+        "arn:aws:dynamodb:*:*:table/*/index/*"
+      ]
+    }
+  ]
+}

--- a/simulation/dynamodb/eks/trust-relationship.json
+++ b/simulation/dynamodb/eks/trust-relationship.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowEksAuthToAssumeRoleForPodIdentity",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "pods.eks.amazonaws.com"
+            },
+            "Action": [
+                "sts:AssumeRole",
+                "sts:TagSession"
+            ]
+        }
+    ]
+}

--- a/simulation/dynamodb/kubernetes/deployments.yaml
+++ b/simulation/dynamodb/kubernetes/deployments.yaml
@@ -1,0 +1,229 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: akka
+  name: engine
+  labels:
+    app: appka
+    deployment: engine
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      deployment: engine
+  template:
+    metadata:
+      labels:
+        app: appka
+        deployment: engine
+    spec:
+      containers:
+        - name: akka-projection-testing
+          # NOTE: replace with published image
+          image: akka-projection-testing:latest
+          imagePullPolicy: Always
+          args:
+            - -J-XX:InitialRAMPercentage=75
+            - -J-XX:MaxRAMPercentage=75
+            - -J-XX:MaxHeapFreeRatio=100
+            - -J-XX:+AlwaysActAsServerClassMachine
+            - -Dconfig.resource=dynamodb.conf
+            - -Dakka.cluster.roles.0=engine
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 15000m
+            limits:
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: management
+            periodSeconds: 10
+            failureThreshold: 3
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/alive"
+              port: management
+            periodSeconds: 10
+            failureThreshold: 5
+            initialDelaySeconds: 20
+          ports:
+            - name: management
+              containerPort: 8558
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: AWS_REGION
+              value: us-east-2
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REQUIRED_CONTACT_POINT_NR
+              value: "3"
+            - name: AKKA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: akka-license-key
+                  key: akka-license-key
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: akka
+  name: entities
+  labels:
+    app: appka
+    deployment: entities
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      deployment: entities
+  template:
+    metadata:
+      labels:
+        app: appka
+        deployment: entities
+    spec:
+      containers:
+        - name: akka-projection-testing
+          # NOTE: replace with published image
+          image: akka-projection-testing:latest
+          imagePullPolicy: Always
+          args:
+            - -J-XX:InitialRAMPercentage=75
+            - -J-XX:MaxRAMPercentage=75
+            - -J-XX:MaxHeapFreeRatio=100
+            - -J-XX:+AlwaysActAsServerClassMachine
+            - -Dconfig.resource=dynamodb.conf
+            - -Dakka.cluster.roles.0=write-model
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3500m
+            limits:
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: management
+            periodSeconds: 10
+            failureThreshold: 3
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/alive"
+              port: management
+            periodSeconds: 10
+            failureThreshold: 5
+            initialDelaySeconds: 20
+          ports:
+            - name: management
+              containerPort: 8558
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: AWS_REGION
+              value: us-east-2
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REQUIRED_CONTACT_POINT_NR
+              value: "3"
+            - name: AKKA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: akka-license-key
+                  key: akka-license-key
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: akka
+  name: projections
+  labels:
+    app: appka
+    deployment: projections
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      deployment: projections
+  template:
+    metadata:
+      labels:
+        app: appka
+        deployment: projections
+    spec:
+      containers:
+        - name: akka-projection-testing
+          # NOTE: replace with published image
+          image: akka-projection-testing:latest
+          imagePullPolicy: Always
+          args:
+            - -J-XX:InitialRAMPercentage=75
+            - -J-XX:MaxRAMPercentage=75
+            - -J-XX:MaxHeapFreeRatio=100
+            - -J-XX:+AlwaysActAsServerClassMachine
+            - -Dconfig.resource=dynamodb.conf
+            - -Dakka.cluster.roles.0=read-model
+            - -Devent-processor.parallelism=8
+            - -Devent-processor.projection-failure-every=500000
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3500m
+            limits:
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: management
+            periodSeconds: 10
+            failureThreshold: 3
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/alive"
+              port: management
+            periodSeconds: 10
+            failureThreshold: 5
+            initialDelaySeconds: 20
+          ports:
+            - name: management
+              containerPort: 8558
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: AWS_REGION
+              value: us-east-2
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REQUIRED_CONTACT_POINT_NR
+              value: "3"
+            - name: AKKA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: akka-license-key
+                  key: akka-license-key

--- a/simulation/dynamodb/kubernetes/namespace.yaml
+++ b/simulation/dynamodb/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: akka

--- a/simulation/dynamodb/kubernetes/podmonitor.yaml
+++ b/simulation/dynamodb/kubernetes/podmonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: akka-projection-testing
+  namespace: akka
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: appka
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 10s

--- a/simulation/dynamodb/kubernetes/rbac.yaml
+++ b/simulation/dynamodb/kubernetes/rbac.yaml
@@ -1,0 +1,22 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-reader
+  namespace: akka
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-pods
+  namespace: akka
+subjects:
+  - kind: User
+    name: system:serviceaccount:akka:default
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/simulation/dynamodb/kubernetes/secrets.yaml
+++ b/simulation/dynamodb/kubernetes/secrets.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: akka
+  name: akka-license-key
+type: Opaque
+# NOTE: update to actual akka license key
+stringData:
+  akka-license-key: <akka-license-key>

--- a/simulation/dynamodb/scripts/create-tables.sh
+++ b/simulation/dynamodb/scripts/create-tables.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+default_read=5
+default_write=5
+
+journal_read=$default_read
+journal_write=$default_write
+snapshot_read=$default_read
+snapshot_write=$default_write
+offset_read=$default_read
+offset_write=$default_write
+events_read=$default_read
+events_write=$default_write
+results_read=$default_read
+results_write=$default_write
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --all-read)
+      journal_read="$2"
+      snapshot_read="$2"
+      offset_read="$2"
+      events_read="$2"
+      results_read="$2"
+      shift 2
+      ;;
+    --all-write)
+      journal_write="$2"
+      snapshot_write="$2"
+      offset_write="$2"
+      events_write="$2"
+      results_write="$2"
+      shift 2
+      ;;
+    # event journal table
+    --journal-read)
+      journal_read="$2"
+      shift 2
+      ;;
+    --journal-write)
+      journal_write="$2"
+      shift 2
+      ;;
+    # snapshot table
+    --snapshot-read)
+      snapshot_read="$2"
+      shift 2
+      ;;
+    --snapshot-write)
+      snapshot_write="$2"
+      shift 2
+      ;;
+    # timestamp offset table
+    --offset-read)
+      offset_read="$2"
+      shift 2
+      ;;
+    --offset-write)
+      offset_write="$2"
+      shift 2
+      ;;
+    # events table
+    --events-read)
+      events_read="$2"
+      shift 2
+      ;;
+    --events-write)
+      events_write="$2"
+      shift 2
+      ;;
+    # results table
+    --results-read)
+      results_read="$2"
+      shift 2
+      ;;
+    --results-write)
+      results_write="$2"
+      shift 2
+      ;;
+    -h|--help)
+      echo "Usage: $0 [OPTIONS]"
+      echo ""
+      echo "Global options:"
+      echo "  --all-read                   Set read capacity for all tables (default: $default_read)"
+      echo "  --all-write                  Set write capacity for all tables (default: $default_write)"
+      echo ""
+      echo "Table-specific options:"
+      echo "  --journal-read               Read capacity for event_journal table"
+      echo "  --journal-write              Write capacity for event_journal table"
+      echo "  --snapshot-read              Read capacity for snapshot table"
+      echo "  --snapshot-write             Write capacity for snapshot table"
+      echo "  --offset-read                Read capacity for timestamp_offset table"
+      echo "  --offset-write               Write capacity for timestamp_offset table"
+      echo "  --events-read                Read capacity for events table"
+      echo "  --events-write               Write capacity for events table"
+      echo "  --results-read               Read capacity for results table"
+      echo "  --results-write              Write capacity for results table"
+      echo ""
+      echo "  -h, --help                   Show this help message"
+      echo ""
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Use -h or --help for usage information"
+      exit 1
+      ;;
+  esac
+done
+
+echo "Creating DynamoDB tables with the following capacity units:"
+echo "  event_journal: Read=$journal_read, Write=$journal_write"
+echo "  snapshot: Read=$snapshot_read, Write=$snapshot_write"
+echo "  timestamp_offset: Read=$offset_read, Write=$offset_write"
+echo "  events: Read=$events_read, Write=$events_write"
+echo "  results: Read=$results_read, Write=$results_write"
+echo ""
+
+aws dynamodb create-table \
+  --table-name event_journal \
+  --attribute-definitions \
+      AttributeName=pid,AttributeType=S \
+      AttributeName=seq_nr,AttributeType=N \
+      AttributeName=entity_type_slice,AttributeType=S \
+      AttributeName=ts,AttributeType=N \
+  --key-schema \
+      AttributeName=pid,KeyType=HASH \
+      AttributeName=seq_nr,KeyType=RANGE \
+  --provisioned-throughput \
+      ReadCapacityUnits=$journal_read,WriteCapacityUnits=$journal_write \
+  --global-secondary-indexes \
+    "[
+        {
+          \"IndexName\": \"event_journal_slice_idx\",
+          \"KeySchema\": [
+            {\"AttributeName\": \"entity_type_slice\", \"KeyType\": \"HASH\"},
+            {\"AttributeName\": \"ts\", \"KeyType\": \"RANGE\"}
+          ],
+          \"Projection\": {
+            \"ProjectionType\": \"ALL\"
+          },
+          \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": $journal_read,
+            \"WriteCapacityUnits\": $journal_write
+          }
+      }
+    ]"
+
+aws dynamodb create-table \
+  --table-name snapshot \
+  --attribute-definitions \
+      AttributeName=pid,AttributeType=S \
+      AttributeName=entity_type_slice,AttributeType=S \
+      AttributeName=event_timestamp,AttributeType=N \
+  --key-schema \
+      AttributeName=pid,KeyType=HASH \
+  --provisioned-throughput \
+      ReadCapacityUnits=$snapshot_read,WriteCapacityUnits=$snapshot_write \
+  --global-secondary-indexes \
+    "[
+        {
+          \"IndexName\": \"snapshot_slice_idx\",
+          \"KeySchema\": [
+            {\"AttributeName\": \"entity_type_slice\", \"KeyType\": \"HASH\"},
+            {\"AttributeName\": \"event_timestamp\", \"KeyType\": \"RANGE\"}
+          ],
+          \"Projection\": {
+            \"ProjectionType\": \"ALL\"
+          },
+          \"ProvisionedThroughput\": {
+            \"ReadCapacityUnits\": $snapshot_read,
+            \"WriteCapacityUnits\": $snapshot_write
+          }
+      }
+    ]"
+
+aws dynamodb create-table \
+  --table-name timestamp_offset \
+  --attribute-definitions \
+      AttributeName=name_slice,AttributeType=S \
+      AttributeName=pid,AttributeType=S \
+  --key-schema \
+      AttributeName=name_slice,KeyType=HASH \
+      AttributeName=pid,KeyType=RANGE \
+  --provisioned-throughput \
+      ReadCapacityUnits=$offset_read,WriteCapacityUnits=$offset_write
+
+aws dynamodb create-table \
+  --table-name events \
+  --attribute-definitions \
+      AttributeName=event,AttributeType=S \
+  --key-schema \
+      AttributeName=event,KeyType=HASH \
+  --provisioned-throughput \
+      ReadCapacityUnits=$events_read,WriteCapacityUnits=$events_write
+
+aws dynamodb create-table \
+  --table-name results \
+  --attribute-definitions \
+      AttributeName=test_name,AttributeType=S \
+  --key-schema \
+      AttributeName=test_name,KeyType=HASH \
+  --provisioned-throughput \
+      ReadCapacityUnits=$results_read,WriteCapacityUnits=$results_write

--- a/simulation/dynamodb/scripts/delete-tables.sh
+++ b/simulation/dynamodb/scripts/delete-tables.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+aws dynamodb delete-table --table-name event_journal
+aws dynamodb delete-table --table-name snapshot
+aws dynamodb delete-table --table-name timestamp_offset
+
+aws dynamodb delete-table --table-name events
+aws dynamodb delete-table --table-name results

--- a/simulation/dynamodb/tests/pubsub-threshold-dance.json
+++ b/simulation/dynamodb/tests/pubsub-threshold-dance.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../../schema/run-simulation.json",
+  "simulation": {
+    "name": "pubsub-threshold-dance",
+    "description": "Pubsub threshold dance for 4 nodes (oscillates around 1600 events/s, 400/s per node)",
+    "stages": [
+      {
+        "name": "warmup-below-threshold",
+        "duration": "10m",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "10k" }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "linear",
+                  "initial": "0/s",
+                  "target": "150/s"
+                }
+              },
+              "duration": "10s",
+              "event": {
+                "frequency": "1/s",
+                "dataSize": "128B"
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      },
+      {
+        "name": "oscillating-threshold",
+        "duration": "4h",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "10k" }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "sinusoidal",
+                  "base": "160/s",
+                  "amplitude": "80/s",
+                  "period": "20m"
+                }
+              },
+              "duration": "10s",
+              "event": {
+                "frequency": "1/s",
+                "dataSize": "128B"
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      }
+    ],
+    "engine": {
+      "tick": "100ms",
+      "parallelism": 8,
+      "ackPersists": false,
+      "validationTimeout": "5m"
+    }
+  }
+}

--- a/simulation/dynamodb/tests/wandering.json
+++ b/simulation/dynamodb/tests/wandering.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "../../schema/run-simulation.json",
+  "simulation": {
+    "name": "wandering",
+    "description": "A full day of random walks",
+    "stages": [
+      {
+        "name": "random-walks",
+        "duration": "1 day",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "1M" }
+            },
+            "activity": {
+              "frequency": {
+                "function": "random-walk",
+                "initial": "1/s",
+                "min": "0.01/s",
+                "max": "5/s",
+                "volatility": 0.1,
+                "trend": 0.0
+              },
+              "duration": {
+                "distribution": "log-normal",
+                "min": "10s",
+                "median": "5m",
+                "p95": "25m",
+                "max": "30m"
+              },
+              "event": {
+                "frequency": {
+                  "function": "random-walk",
+                  "initial": "0.5/s",
+                  "min": "0.01/s",
+                  "max": "3/s",
+                  "volatility": 0.1,
+                  "trend": 0.0
+                },
+                "dataSize": {
+                  "distribution": "log-normal",
+                  "min": "16B",
+                  "median": "64B",
+                  "p95": "256B",
+                  "max": "512B"
+                }
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      }
+    ],
+    "engine": {
+      "tick": "200ms",
+      "parallelism": 8,
+      "ackPersists": false,
+      "validationTimeout": "30m"
+    }
+  }
+}

--- a/simulation/examples/multi.json
+++ b/simulation/examples/multi.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "../schema/run-simulation.json",
+  "simulation": {
+    "name": "Multi-stage test",
+    "description": "Simulates a warm-up, peak load, and cool-down phase.",
+    "stages": [
+      {
+        "name": "Warm-up",
+        "duration": "3m",
+        "generators": [
+          {
+            "entityId": {
+              "entity": {
+                "count": "10k"
+              }
+            },
+            "activity": {
+              "frequency": "5/s",
+              "duration": {
+                "distribution": "exponential",
+                "mean": "5s",
+                "min": "1s",
+                "max": "15s"
+              },
+              "event": {
+                "frequency": "2/s",
+                "dataSize": "256B"
+              }
+            },
+            "random": {
+              "seed": 1001
+            }
+          }
+        ]
+      },
+      {
+        "name": "Peak load",
+        "duration": "5m",
+        "generators": [
+          {
+            "entityId": {
+              "entity": {
+                "count": "10k"
+              },
+              "sliceDistribution": {
+                "type": "zipf",
+                "exponent": 1.1,
+                "shuffled": true
+              }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "sinusoidal",
+                  "base": "20/s",
+                  "amplitude": "10/s",
+                  "period": "30s"
+                }
+              },
+              "duration": {
+                "distribution": "log-normal",
+                "median": "8s",
+                "p95": "20s",
+                "min": "2s",
+                "max": "30s"
+              },
+              "event": {
+                "frequency": "5/s",
+                "dataSize": {
+                  "distribution": "weibull",
+                  "shape": 1.5,
+                  "scale": "1kB",
+                  "min": "100B",
+                  "max": "5kB"
+                }
+              }
+            },
+            "random": {
+              "seed": 2002
+            }
+          }
+        ]
+      },
+      {
+        "name": "Cool-down",
+        "duration": "2m",
+        "delay": "10s",
+        "generators": [
+          {
+            "entityId": {
+              "entity": {
+                "count": "10k"
+              }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "linear",
+                  "initial": "10/s",
+                  "target": "1/s"
+                }
+              },
+              "duration": "3s",
+              "event": {
+                "frequency": "1/s",
+                "dataSize": "128B"
+              }
+            },
+            "random": {
+              "seed": 3003
+            }
+          }
+        ]
+      }
+    ],
+    "engine": {
+      "tick": "100ms",
+      "parallelism": 8,
+      "ackPersists": false
+    }
+  }
+}

--- a/simulation/examples/simple.json
+++ b/simulation/examples/simple.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "../schema/run-simulation.json",
+  "simulation": {
+    "name": "Simple",
+    "description": "Simple simulation with uniform distribution over entities.",
+    "stages": [
+      {
+        "duration": "1 minute",
+        "generators": [
+          {
+            "entityId": {
+              "entity": {
+                "count": "10k"
+              }
+            },
+            "activity": {
+              "frequency": "10 / second",
+              "duration": "10 seconds",
+              "event": {
+                "frequency": "1 / second",
+                "dataSize": "100 B"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/simulation/r2dbc/kubernetes/deployments.yaml
+++ b/simulation/r2dbc/kubernetes/deployments.yaml
@@ -1,0 +1,278 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: akka
+  name: engine
+  labels:
+    app: appka
+    deployment: engine
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      deployment: engine
+  template:
+    metadata:
+      labels:
+        app: appka
+        deployment: engine
+    spec:
+      containers:
+        - name: akka-projection-testing
+          # NOTE: replace with published image
+          image: akka-projection-testing:latest
+          imagePullPolicy: Always
+          args:
+            - -J-XX:InitialRAMPercentage=75
+            - -J-XX:MaxRAMPercentage=75
+            - -J-XX:MaxHeapFreeRatio=100
+            - -J-XX:+AlwaysActAsServerClassMachine
+            - -Dconfig.resource=r2dbc.conf
+            - -Dakka.cluster.roles.0=engine
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 15000m
+            limits:
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: management
+            periodSeconds: 10
+            failureThreshold: 3
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/alive"
+              port: management
+            periodSeconds: 10
+            failureThreshold: 5
+            initialDelaySeconds: 20
+          ports:
+            - name: management
+              containerPort: 8558
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REQUIRED_CONTACT_POINT_NR
+              value: "3"
+            - name: AKKA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: akka-license-key
+                  key: akka-license-key
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: host
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: DB_SSL_ENABLED
+              value: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: akka
+  name: entities
+  labels:
+    app: appka
+    deployment: entities
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      deployment: entities
+  template:
+    metadata:
+      labels:
+        app: appka
+        deployment: entities
+    spec:
+      containers:
+        - name: akka-projection-testing
+          # NOTE: replace with published image
+          image: akka-projection-testing:latest
+          imagePullPolicy: Always
+          args:
+            - -J-XX:InitialRAMPercentage=75
+            - -J-XX:MaxRAMPercentage=75
+            - -J-XX:MaxHeapFreeRatio=100
+            - -J-XX:+AlwaysActAsServerClassMachine
+            - -Dconfig.resource=r2dbc.conf
+            - -Dakka.cluster.roles.0=write-model
+            - -Dakka.persistence.r2dbc.connection-factory.initial-size=20
+            - -Dakka.persistence.r2dbc.connection-factory.max-size=40
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3500m
+            limits:
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: management
+            periodSeconds: 10
+            failureThreshold: 3
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/alive"
+              port: management
+            periodSeconds: 10
+            failureThreshold: 5
+            initialDelaySeconds: 20
+          ports:
+            - name: management
+              containerPort: 8558
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REQUIRED_CONTACT_POINT_NR
+              value: "3"
+            - name: AKKA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: akka-license-key
+                  key: akka-license-key
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: host
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: DB_SSL_ENABLED
+              value: "true"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: akka
+  name: projections
+  labels:
+    app: appka
+    deployment: projections
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      deployment: projections
+  template:
+    metadata:
+      labels:
+        app: appka
+        deployment: projections
+    spec:
+      containers:
+        - name: akka-projection-testing
+          # NOTE: replace with published image
+          image: akka-projection-testing:latest
+          imagePullPolicy: Always
+          args:
+            - -J-XX:InitialRAMPercentage=75
+            - -J-XX:MaxRAMPercentage=75
+            - -J-XX:MaxHeapFreeRatio=100
+            - -J-XX:+AlwaysActAsServerClassMachine
+            - -Dconfig.resource=r2dbc.conf
+            - -Dakka.cluster.roles.0=read-model
+            - -Dakka.persistence.r2dbc.connection-factory.initial-size=20
+            - -Dakka.persistence.r2dbc.connection-factory.max-size=40
+            - -Devent-processor.parallelism=8
+            - -Devent-processor.projection-failure-every=500000
+          resources:
+            requests:
+              memory: 4Gi
+              cpu: 3500m
+            limits:
+              memory: 4Gi
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: management
+            periodSeconds: 10
+            failureThreshold: 3
+            initialDelaySeconds: 10
+          livenessProbe:
+            httpGet:
+              path: "/alive"
+              port: management
+            periodSeconds: 10
+            failureThreshold: 5
+            initialDelaySeconds: 20
+          ports:
+            - name: management
+              containerPort: 8558
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9001
+              protocol: TCP
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: REQUIRED_CONTACT_POINT_NR
+              value: "3"
+            - name: AKKA_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: akka-license-key
+                  key: akka-license-key
+            - name: DB_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: host
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: username
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-credentials
+                  key: password
+            - name: DB_SSL_ENABLED
+              value: "true"

--- a/simulation/r2dbc/kubernetes/namespace.yaml
+++ b/simulation/r2dbc/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: akka

--- a/simulation/r2dbc/kubernetes/podmonitor.yaml
+++ b/simulation/r2dbc/kubernetes/podmonitor.yaml
@@ -1,0 +1,14 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: akka-projection-testing
+  namespace: akka
+  labels:
+    release: prometheus
+spec:
+  selector:
+    matchLabels:
+      app: appka
+  podMetricsEndpoints:
+    - port: metrics
+      interval: 10s

--- a/simulation/r2dbc/kubernetes/rbac.yaml
+++ b/simulation/r2dbc/kubernetes/rbac.yaml
@@ -1,0 +1,22 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: pod-reader
+  namespace: akka
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "watch", "list"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: read-pods
+  namespace: akka
+subjects:
+  - kind: User
+    name: system:serviceaccount:akka:default
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/simulation/r2dbc/kubernetes/secrets.yaml
+++ b/simulation/r2dbc/kubernetes/secrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: akka
+  name: akka-license-key
+type: Opaque
+# NOTE: update to actual akka license key
+stringData:
+  akka-license-key: <akka-license-key>
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  namespace: akka
+  name: postgres-credentials
+type: Opaque
+# NOTE: update to actual credentials
+stringData:
+  host: postgres
+  username: postgres
+  password: postgres

--- a/simulation/r2dbc/postgres/README.md
+++ b/simulation/r2dbc/postgres/README.md
@@ -1,0 +1,14 @@
+Create psql docker image:
+
+```sh
+cd image
+docker buildx build --platform linux/amd64 -t psql:latest .
+```
+
+Publish image to somewhere available to kubernetes.
+
+Run in kubernetes (default kubectl context, default akka namespace):
+
+```sh
+scripts/psql.sh --image <published image>
+```

--- a/simulation/r2dbc/postgres/image/Dockerfile
+++ b/simulation/r2dbc/postgres/image/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.21
+RUN apk --no-cache add postgresql-client

--- a/simulation/r2dbc/postgres/scripts/psql.sh
+++ b/simulation/r2dbc/postgres/scripts/psql.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Connect psql to Postgres via Kubernetes.
+#
+# Expects postgres-credentials secret in the namespace.
+#
+# Options:
+#
+#   --context CONTEXT      the kubectl context to use (otherwise default context)
+#   --image IMAGE          override the docker image to use (with postgresql client installed)
+#   --namespace NAMESPACE  kubernetes namespace to run in with postgres-credentials secret (default: akka)
+
+set -euo pipefail
+
+# logs and failures
+
+function red {
+  echo -en "\033[0;31m$@\033[0m"
+}
+
+function blue {
+  echo -en "\033[0;34m$@\033[0m"
+}
+
+function error {
+  echo $(red "$@") 1>&2
+}
+
+function fail {
+  error "$@"
+  exit 1
+}
+
+# requirements
+
+function command_exists {
+  type -P "$1" > /dev/null 2>&1
+}
+
+command_exists "kubectl" || fail "kubectl command is required"
+
+# options
+
+declare -a kubectl_args=()
+declare image="psql:latest"
+declare namespace="akka"
+
+while [[ $# -gt 0 ]] ; do
+  case "$1" in
+    --context     ) kubectl_args+=("--context" "$2") ; shift 2 ;;
+    --image       ) image="$2"                       ; shift 2 ;;
+    --namespace   ) namespace="$2"                   ; shift 2 ;;
+    *             ) fail "unknown option: $1"        ; shift   ;;
+  esac
+done
+
+kubectl_args+=("--namespace" "$namespace")
+
+function __kubectl {
+  kubectl ${kubectl_args[@]+"${kubectl_args[@]}"} "$@"
+}
+
+# create pod definition
+
+pod_yaml_file=$(mktemp)
+trap "rm -f $pod_yaml_file" EXIT
+
+cat > "$pod_yaml_file" << EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: psql-
+spec:
+  containers:
+    - name: psql
+      image: $image
+      imagePullPolicy: IfNotPresent
+      command: ["psql"]
+      tty: true
+      stdin: true
+      stdinOnce: true
+      env:
+        - name: PGHOST
+          valueFrom:
+            secretKeyRef:
+              name: postgres-credentials
+              key: host
+        - name: PGUSER
+          valueFrom:
+            secretKeyRef:
+              name: postgres-credentials
+              key: username
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: postgres-credentials
+              key: password
+  restartPolicy: Never
+EOF
+
+# create the pod
+
+readonly pod=$(__kubectl create -o name -f "$pod_yaml_file")
+readonly pod_name=$(echo $pod | cut -d/ -f2)
+
+echo "Created $(blue $pod). Waiting for pod to start..."
+__kubectl wait --for=condition=Ready --timeout=5m $pod > /dev/null
+
+function delete_pod {
+  __kubectl delete $pod --wait=false
+}
+
+trap delete_pod EXIT
+
+# attach to the pod
+
+echo "Attaching to pod..."
+__kubectl attach -it $pod

--- a/simulation/r2dbc/tests/multi-day.json
+++ b/simulation/r2dbc/tests/multi-day.json
@@ -1,0 +1,166 @@
+{
+  "$schema": "../../schema/run-simulation.json",
+  "simulation": {
+    "name": "multi-day",
+    "description": "Multiple days of complex random walks with daily rhythms, bursts, and quiet periods",
+    "stages": [
+      {
+        "name": "complex-random-walks",
+        "duration": "3 days",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "1M" }
+            },
+            "activity": {
+              "frequency": {
+                "function": "additive",
+                "additiveRates": [
+                  {
+                    "function": "modulated",
+                    "carrier": {
+                      "function": "random-walk",
+                      "initial": "0.1/s",
+                      "min": "0/s",
+                      "max": "1/s",
+                      "volatility": 0.1,
+                      "trend": 0.0
+                    },
+                    "modulator": {
+                      "function": "sinusoidal",
+                      "base": "0/s",
+                      "amplitude": "1/s",
+                      "period": "24h"
+                    }
+                  },
+                  {
+                    "function": "burst",
+                    "base": "0/s",
+                    "peak": "1/s",
+                    "start": "1h",
+                    "rampUp": "30m",
+                    "burst": "1h",
+                    "rampDown": "30m"
+                  },
+                  {
+                    "function": "burst",
+                    "base": "0/s",
+                    "peak": "2/s",
+                    "start": "8h",
+                    "rampUp": "1h",
+                    "burst": "2h",
+                    "rampDown": "1h"
+                  },
+                  {
+                    "function": "burst",
+                    "base": "0/s",
+                    "peak": "1/s",
+                    "start": "25h",
+                    "rampUp": "30m",
+                    "burst": "1h",
+                    "rampDown": "30m"
+                  },
+                  {
+                    "function": "burst",
+                    "base": "0/s",
+                    "peak": "2/s",
+                    "start": "32h",
+                    "rampUp": "1h",
+                    "burst": "2h",
+                    "rampDown": "1h"
+                  },
+                  {
+                    "function": "burst",
+                    "base": "0/s",
+                    "peak": "1/s",
+                    "start": "49h",
+                    "rampUp": "30m",
+                    "burst": "1h",
+                    "rampDown": "30m"
+                  },
+                  {
+                    "function": "burst",
+                    "base": "0/s",
+                    "peak": "2/s",
+                    "start": "57h",
+                    "rampUp": "1h",
+                    "burst": "2h",
+                    "rampDown": "1h"
+                  }
+                ]
+              },
+              "duration": {
+                "distribution": "composite",
+                "samplers": [
+                  {
+                    "sampler": {
+                      "distribution": "log-normal",
+                      "min": "5s",
+                      "median": "2m",
+                      "p95": "15m",
+                      "max": "20m"
+                    },
+                    "weight": 0.7
+                  },
+                  {
+                    "sampler": {
+                      "distribution": "log-normal",
+                      "min": "15m",
+                      "median": "45m",
+                      "p95": "2h",
+                      "max": "3h"
+                    },
+                    "weight": 0.3
+                  }
+                ]
+              },
+              "event": {
+                "frequency": {
+                  "function": "composite",
+                  "compositeRates": [
+                    {
+                      "rate": {
+                        "function": "random-walk",
+                        "initial": "0.5/s",
+                        "min": "0.01/s",
+                        "max": "2/s",
+                        "volatility": 0.1,
+                        "trend": 0.0
+                      },
+                      "weight": 0.6
+                    },
+                    {
+                      "rate": {
+                        "function": "sinusoidal",
+                        "base": "0/s",
+                        "amplitude": "2/s",
+                        "period": "1h"
+                      },
+                      "weight": 0.4
+                    }
+                  ]
+                },
+                "dataSize": {
+                  "distribution": "log-normal",
+                  "min": "16B",
+                  "median": "64B",
+                  "p95": "512B",
+                  "max": "1kB"
+                }
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      }
+    ],
+    "engine": {
+      "tick": "200ms",
+      "parallelism": 8,
+      "ackPersists": false,
+      "validationTimeout": "30m"
+    }
+  }
+}

--- a/simulation/r2dbc/tests/overwhelming-burst.json
+++ b/simulation/r2dbc/tests/overwhelming-burst.json
@@ -1,0 +1,114 @@
+{
+  "$schema": "../../schema/run-simulation.json",
+  "simulation": {
+    "name": "overwhelming-burst",
+    "description": "Initial quiet period followed by massive burst and then recovery period",
+    "stages": [
+      {
+        "name": "quiet-period",
+        "duration": "30m",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "100k" }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "sinusoidal",
+                  "base": "5/s",
+                  "amplitude": "5/s",
+                  "period": "5m"
+                }
+              },
+              "duration": {
+                "distribution": "exponential",
+                "min": "1s",
+                "mean": "10s",
+                "max": "1m"
+              },
+              "event": {
+                "frequency": {
+                  "function": "random-walk",
+                  "initial": "1/s",
+                  "min": "0.1/s",
+                  "max": "10/s",
+                  "volatility": 2.0,
+                  "trend": 0.0
+                },
+                "dataSize": "128B"
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      },
+      {
+        "name": "massive-burst",
+        "duration": "10m",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "100k" }
+            },
+            "activity": {
+              "frequency": "500/s",
+              "duration": {
+                "distribution": "exponential",
+                "min": "1s",
+                "mean": "5s",
+                "max": "30s"
+              },
+              "event": {
+                "frequency": "5/s",
+                "dataSize": {
+                  "distribution": "log-normal",
+                  "median": "512B",
+                  "p95": "2kB",
+                  "max": "4kB"
+                }
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      },
+      {
+        "name": "recovery-period",
+        "duration": "20m",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "100k" }
+            },
+            "activity": {
+              "frequency": {
+                "function": "linear",
+                "initial": "100/s",
+                "target": "1/s"
+              },
+              "duration": "5s",
+              "event": {
+                "frequency": "2/s",
+                "dataSize": "128B"
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      }
+    ],
+    "engine": {
+      "tick": "200ms",
+      "parallelism": 8,
+      "ackPersists": false,
+      "validationTimeout": "30m"
+    }
+  }
+}

--- a/simulation/r2dbc/tests/pubsub-threshold-dance.json
+++ b/simulation/r2dbc/tests/pubsub-threshold-dance.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "../../schema/run-simulation.json",
+  "simulation": {
+    "name": "pubsub-threshold-dance",
+    "description": "Pubsub threshold dance for 5 nodes (oscillates around 2000 events/s, 400/s per node)",
+    "stages": [
+      {
+        "name": "warmup-below-threshold",
+        "duration": "10m",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "10k" }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "linear",
+                  "initial": "0/s",
+                  "target": "200/s"
+                }
+              },
+              "duration": "10s",
+              "event": {
+                "frequency": "1/s",
+                "dataSize": "128B"
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      },
+      {
+        "name": "oscillating-threshold",
+        "duration": "4h",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "10k" }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "sinusoidal",
+                  "base": "200/s",
+                  "amplitude": "100/s",
+                  "period": "20m"
+                }
+              },
+              "duration": "10s",
+              "event": {
+                "frequency": "1/s",
+                "dataSize": "128B"
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      }
+    ],
+    "engine": {
+      "tick": "100ms",
+      "parallelism": 8,
+      "ackPersists": false,
+      "validationTimeout": "5m"
+    }
+  }
+}

--- a/simulation/r2dbc/tests/variations.json
+++ b/simulation/r2dbc/tests/variations.json
@@ -1,0 +1,348 @@
+{
+  "$schema": "../../schema/run-simulation.json",
+  "simulation": {
+    "name": "variations",
+    "description": "Diverse distributions and activity patterns across slices",
+    "stages": [
+      {
+        "name": "slice-variations-and-hotspots",
+        "duration": "6h",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "10k" },
+              "slices": "0-127",
+              "sliceDistribution": {
+                "type": "zipf",
+                "exponent": 1.1,
+                "shuffled": true
+              }
+            },
+            "activity": {
+              "frequency": "15/s",
+              "duration": {
+                "distribution": "exponential",
+                "mean": "2s",
+                "min": "500ms",
+                "max": "10s"
+              },
+              "event": {
+                "frequency": "2/s",
+                "dataSize": {
+                  "distribution": "log-normal",
+                  "median": "512B",
+                  "p95": "2kB"
+                }
+              }
+            },
+            "random": {
+              "seed": 1010101
+            }
+          },
+          {
+            "entityId": {
+              "entity": { "count": "10k" },
+              "slices": "128-255",
+              "sliceDistribution": {
+                "type": "exponential",
+                "shuffled": false
+              }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "sinusoidal",
+                  "base": "8/s",
+                  "amplitude": "4/s",
+                  "period": "30m"
+                }
+              },
+              "duration": {
+                "distribution": "weibull",
+                "scale": "4s",
+                "shape": 1.5
+              },
+              "event": {
+                "frequency": "0.5/s",
+                "dataSize": "2kB"
+              }
+            },
+            "random": {
+              "seed": 2020202
+            }
+          },
+          {
+            "entityId": {
+              "entity": { "count": "10k" },
+              "slices": "256-383",
+              "sliceDistribution": {
+                "type": "pareto",
+                "shape": 1.1,
+                "shuffled": true
+              }
+            },
+            "activity": {
+              "frequency": "5/s",
+              "duration": {
+                "distribution": "gamma",
+                "shape": 2.0,
+                "scale": "3s"
+              },
+              "event": {
+                "frequency": {
+                  "rate": {
+                    "function": "random-walk",
+                    "initial": "1.5/s",
+                    "min": "0.5/s",
+                    "max": "3/s",
+                    "volatility": 0.4
+                  }
+                },
+                "dataSize": {
+                  "distribution": "pareto",
+                  "min": "256B",
+                  "p95": "4kB"
+                }
+              }
+            },
+            "random": {
+              "seed": 3030303
+            }
+          },
+          {
+            "entityId": {
+              "entity": { "count": "10k" },
+              "slices": "384-511",
+              "sliceDistribution": {
+                "type": "uniform"
+              }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "burst",
+                  "base": "3/s",
+                  "peak": "25/s",
+                  "start": "2h",
+                  "rampUp": "15m",
+                  "burst": "45m",
+                  "rampDown": "30m"
+                }
+              },
+              "duration": "1s",
+              "event": {
+                "frequency": "5/s",
+                "dataSize": {
+                  "distribution": "uniform",
+                  "min": "128B",
+                  "max": "1kB"
+                }
+              }
+            },
+            "random": {
+              "seed": 4040404
+            }
+          },
+          {
+            "entityId": {
+              "entity": { "count": "10k" },
+              "slices": "512-639",
+              "sliceDistribution": {
+                "type": "log-normal",
+                "shape": 2.0,
+                "shuffled": true
+              }
+            },
+            "activity": {
+              "frequency": "5/s",
+              "duration": {
+                "distribution": "categorical",
+                "categories": [
+                  { "value": "1s", "weight": 0.4 },
+                  { "value": "5s", "weight": 0.3 },
+                  { "value": "15s", "weight": 0.2 },
+                  { "value": "30s", "weight": 0.1 }
+                ]
+              },
+              "event": {
+                "frequency": "3/s",
+                "dataSize": "512B"
+              }
+            },
+            "random": {
+              "seed": 5050505
+            }
+          },
+          {
+            "entityId": {
+              "entity": { "count": "10k" },
+              "slices": "640-767",
+              "sliceDistribution": {
+                "type": "gamma",
+                "shape": 2.5,
+                "shuffled": false
+              }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "linear",
+                  "initial": "2/s",
+                  "target": "12/s"
+                }
+              },
+              "duration": {
+                "distribution": "composite",
+                "samplers": [
+                  {
+                    "sampler": {
+                      "distribution": "exponential",
+                      "mean": "2s",
+                      "max": "8s"
+                    },
+                    "weight": 0.7
+                  },
+                  {
+                    "sampler": {
+                      "distribution": "uniform",
+                      "min": "10s",
+                      "max": "60s"
+                    },
+                    "weight": 0.3
+                  }
+                ]
+              },
+              "event": {
+                "frequency": "1.5/s",
+                "dataSize": {
+                  "distribution": "zipf",
+                  "min": "64B",
+                  "max": "8kB",
+                  "exponent": 1.3,
+                  "shuffled": true
+                }
+              }
+            },
+            "random": {
+              "seed": 6060606
+            }
+          },
+          {
+            "entityId": {
+              "entity": { "count": "10k" },
+              "slices": "768-895",
+              "sliceDistribution": {
+                "type": "weibull",
+                "shape": 0.8,
+                "shuffled": true
+              }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "additive",
+                  "additiveRates": [
+                    {
+                      "function": "constant",
+                      "value": "6/s"
+                    },
+                    {
+                      "function": "sinusoidal",
+                      "base": "0/s",
+                      "amplitude": "8/s",
+                      "period": "2h",
+                      "shift": "30m"
+                    }
+                  ]
+                }
+              },
+              "duration": {
+                "distribution": "log-normal",
+                "mu": 1.2,
+                "sigma": 0.6,
+                "min": "500ms",
+                "max": "20s"
+              },
+              "event": {
+                "frequency": {
+                  "function": "sinusoidal",
+                  "base": "2/s",
+                  "amplitude": "1/s",
+                  "period": "10m"
+                },
+                "dataSize": {
+                  "distribution": "gamma",
+                  "shape": 1.5,
+                  "scale": "1kB"
+                }
+              }
+            },
+            "random": {
+              "seed": 7070707
+            }
+          },
+          {
+            "entityId": {
+              "entity": { "count": "10k" },
+              "slices": "896-1023",
+              "sliceDistribution": {
+                "type": "zipf",
+                "exponent": 2.2,
+                "shuffled": false
+              }
+            },
+            "activity": {
+              "frequency": {
+                "rate": {
+                  "function": "modulated",
+                  "carrier": {
+                    "function": "constant",
+                    "value": "10/s"
+                  },
+                  "modulator": {
+                    "function": "random-walk",
+                    "initial": "1.0/s",
+                    "min": "0.2/s",
+                    "max": "2.0/s",
+                    "volatility": 0.3,
+                    "trend": 0.1
+                  },
+                  "strength": 0.8
+                }
+              },
+              "duration": {
+                "distribution": "pareto",
+                "scale": "2s",
+                "shape": 1.6,
+                "max": "45s"
+              },
+              "event": {
+                "frequency": "0.8/s",
+                "dataSize": {
+                  "distribution": "composite",
+                  "samplers": [
+                    {
+                      "sampler": "256B",
+                      "weight": 0.6
+                    },
+                    {
+                      "sampler": {
+                        "distribution": "exponential",
+                        "mean": "4kB",
+                        "max": "16kB"
+                      },
+                      "weight": 0.4
+                    }
+                  ]
+                }
+              }
+            },
+            "random": {
+              "seed": 8080808
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/simulation/r2dbc/tests/wandering.json
+++ b/simulation/r2dbc/tests/wandering.json
@@ -1,0 +1,63 @@
+{
+  "$schema": "../../schema/run-simulation.json",
+  "simulation": {
+    "name": "wandering",
+    "description": "A full day of random walks",
+    "stages": [
+      {
+        "name": "random-walks",
+        "duration": "1 day",
+        "generators": [
+          {
+            "entityId": {
+              "entity": { "count": "1M" }
+            },
+            "activity": {
+              "frequency": {
+                "function": "random-walk",
+                "initial": "1/s",
+                "min": "0.01/s",
+                "max": "5/s",
+                "volatility": 0.1,
+                "trend": 0.0
+              },
+              "duration": {
+                "distribution": "log-normal",
+                "min": "10s",
+                "median": "5m",
+                "p95": "25m",
+                "max": "30m"
+              },
+              "event": {
+                "frequency": {
+                  "function": "random-walk",
+                  "initial": "0.5/s",
+                  "min": "0.01/s",
+                  "max": "3/s",
+                  "volatility": 0.1,
+                  "trend": 0.0
+                },
+                "dataSize": {
+                  "distribution": "log-normal",
+                  "min": "16B",
+                  "median": "64B",
+                  "p95": "512B",
+                  "max": "1kB"
+                }
+              }
+            },
+            "random": {
+              "seed": 123456789
+            }
+          }
+        ]
+      }
+    ],
+    "engine": {
+      "tick": "200ms",
+      "parallelism": 8,
+      "ackPersists": false,
+      "validationTimeout": "30m"
+    }
+  }
+}

--- a/simulation/schema/defs/activity.json
+++ b/simulation/schema/defs/activity.json
@@ -1,0 +1,204 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/activity.json",
+  "title": "Activity settings",
+  "description": "Configuration for activity patterns in the simulation",
+  "$comment": "Activities represent interactions with entities over time. The schema supports hierarchical configurations with different levels of specificity",
+
+  "type": "object",
+  "required": ["frequency"],
+  "properties": {
+    "frequency": {
+      "$ref": "./point-process.json",
+      "description": "Frequency of new activities"
+    },
+    "perSlice": {
+      "type": "object",
+      "description": "Mapping of slices to their respective settings",
+      "additionalProperties": {
+        "$ref": "#/definitions/activityPerSliceSettings"
+      }
+    },
+    "perEntity": {
+      "type": "object",
+      "description": "Mapping of entity indices to their respective settings",
+      "additionalProperties": {
+        "$ref": "#/definitions/activityPerEntitySettings"
+      }
+    },
+    "duration": {
+      "$ref": "./sampler.json",
+      "description": "Sampler for how long the activity with the entity lasts"
+    },
+    "event": {
+      "$ref": "#/definitions/eventSettings",
+      "description": "Settings for event generation during an activity"
+    }
+  },
+
+  "oneOf": [
+    { "required": ["perSlice"] },
+    { "required": ["perEntity"] },
+    { "required": ["duration", "event"] }
+  ],
+
+  "additionalProperties": false,
+
+  "definitions": {
+    "activityPerSliceSettings": {
+      "type": "object",
+      "properties": {
+        "perEntity": {
+          "type": "object",
+          "description": "Mapping of entity indices to their respective settings",
+          "additionalProperties": {
+            "$ref": "#/definitions/activityPerEntitySettings"
+          }
+        },
+        "duration": {
+          "$ref": "./sampler.json",
+          "description": "Sampler for how long the activity with entities in this slice lasts"
+        },
+        "event": {
+          "$ref": "#/definitions/eventSettings",
+          "description": "Settings for event generation during an activity"
+        }
+      },
+      "oneOf": [
+        { "required": ["perEntity"] },
+        { "required": ["duration", "event"] }
+      ],
+      "additionalProperties": false
+    },
+
+    "activityPerEntitySettings": {
+      "type": "object",
+      "required": ["duration", "event"],
+      "properties": {
+        "duration": {
+          "$ref": "./sampler.json",
+          "description": "Sampler for how long the activity with this entity lasts"
+        },
+        "event": {
+          "$ref": "#/definitions/eventSettings",
+          "description": "Settings for event generation during an activity"
+        }
+      },
+      "additionalProperties": false
+    },
+
+    "eventSettings": {
+      "type": "object",
+      "required": ["frequency", "dataSize"],
+      "properties": {
+        "frequency": {
+          "$ref": "./point-process.json",
+          "description": "Frequency of events in an activity"
+        },
+        "dataSize": {
+          "$ref": "./sampler.json",
+          "description": "Data size for each generated event"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+
+  "examples": [
+    {
+      "frequency": "5/s",
+      "duration": "3s",
+      "event": {
+        "frequency": "10/s",
+        "dataSize": "1kB"
+      }
+    },
+    {
+      "frequency": {
+        "process": "poisson",
+        "rate": {
+          "function": "sinusoidal",
+          "base": "10/s",
+          "amplitude": "5/s",
+          "period": "60s"
+        }
+      },
+      "perSlice": {
+        "0-63": {
+          "duration": {
+            "distribution": "log-normal",
+            "median": "2s",
+            "p95": "10s"
+          },
+          "event": {
+            "frequency": "10/s",
+            "dataSize": {
+              "distribution": "log-normal",
+              "median": "512B",
+              "p95": "2kB"
+            }
+          }
+        },
+        "64-127": {
+          "perEntity": {
+            "0-1023": {
+              "duration": "5s",
+              "event": {
+                "frequency": "20/s",
+                "dataSize": "2kB"
+              }
+            },
+            "1024-4095": {
+              "duration": "2s",
+              "event": {
+                "frequency": "5/s",
+                "dataSize": "512B"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "frequency": "2/s",
+      "perEntity": {
+        "0-1023": {
+          "duration": {
+            "distribution": "exponential",
+            "mean": "5s",
+            "min": "1s",
+            "max": "30s"
+          },
+          "event": {
+            "frequency": "20/s",
+            "dataSize": "2kB"
+          }
+        },
+        "1024-4095": {
+          "duration": {
+            "distribution": "weibull",
+            "scale": "5s",
+            "shape": 2.0
+          },
+          "event": {
+            "frequency": {
+              "process": "poisson",
+              "rate": {
+                "function": "random-walk",
+                "initial": "5/s",
+                "min": "1/s",
+                "max": "20/s",
+                "volatility": 0.3
+              }
+            },
+            "dataSize": {
+              "distribution": "pareto",
+              "min": "256B",
+              "p95": "8kB"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/simulation/schema/defs/distribution-shape.json
+++ b/simulation/schema/defs/distribution-shape.json
@@ -1,0 +1,97 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/distribution-shape.json",
+  "title": "Distribution shape settings",
+  "description": "Represents the shape of a distribution used for sampling from a provided min-max range",
+  "$comment": "Distribution shapes define how values are distributed within a range, without specifying the actual range values",
+
+  "type": "object",
+  "required": ["type"],
+  "properties": {
+    "type": {
+      "type": "string",
+      "enum": [
+        "uniform",
+        "zipf",
+        "exponential",
+        "weibull",
+        "gamma",
+        "log-normal",
+        "pareto"
+      ],
+      "description": "Type of distribution shape"
+    },
+    "exponent": {
+      "type": "number",
+      "minimum": 0.1,
+      "description": "Exponent for zipf distribution. Controls the steepness of the distribution"
+    },
+    "shuffled": {
+      "type": "boolean",
+      "description": "Whether to shuffle the distribution to randomize values while preserving frequency distribution. Most meaningful for distributions with unequal probabilities (like zipf, exponential, etc.).",
+      "default": false
+    },
+    "shape": {
+      "type": "number",
+      "minimum": 0.1,
+      "description": "Shape parameter for weibull, gamma, log-normal, pareto distributions"
+    }
+  },
+
+  "allOf": [
+    {
+      "if": {
+        "properties": { "type": { "const": "zipf" } }
+      },
+      "then": {
+        "required": ["exponent"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "type": { "const": "weibull" } }
+      },
+      "then": {
+        "required": ["shape"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "type": { "const": "gamma" } }
+      },
+      "then": {
+        "required": ["shape"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "type": { "const": "log-normal" } }
+      },
+      "then": {
+        "required": ["shape"]
+      }
+    },
+    {
+      "if": {
+        "properties": { "type": { "const": "pareto" } }
+      },
+      "then": {
+        "required": ["shape"]
+      }
+    }
+  ],
+
+  "additionalProperties": false,
+
+  "examples": [
+    { "type": "uniform" },
+    { "type": "exponential" },
+    { "type": "exponential", "shuffled": true },
+    { "type": "zipf", "exponent": 1.2, "shuffled": true },
+    { "type": "weibull", "shape": 2.5 },
+    { "type": "gamma", "shape": 1.5 },
+    { "type": "log-normal", "shape": 0.5 },
+    { "type": "log-normal", "shape": 0.5, "shuffled": true },
+    { "type": "pareto", "shape": 1.5 }
+  ]
+}

--- a/simulation/schema/defs/engine.json
+++ b/simulation/schema/defs/engine.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/engine.json",
+  "title": "Engine settings",
+  "description": "Settings for the simulation execution engine",
+  "$comment": "The engine controls how the simulation is executed, including timing, parallelism, and persistence behavior",
+
+  "type": "object",
+  "properties": {
+    "tick": {
+      "$ref": "./types.json#/definitions/duration",
+      "description": "Time interval for simulation clock advancement. Lower values provide more precise timing but may increase computational overhead.",
+      "default": "200ms"
+    },
+    "parallelism": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Degree of parallel execution for simulation activities. Higher values may improve throughput but require more system resources.",
+      "default": 4
+    },
+    "ackPersists": {
+      "type": "boolean",
+      "description": "Whether to wait for acknowledgment for entity persists. Set to true for maximum consistency, false for higher throughput.",
+      "default": false
+    },
+    "validationTimeout": {
+      "$ref": "./types.json#/definitions/duration",
+      "description": "Timeout for projection validation after simulation completes. Should be long enough to allow for projections to catch up.",
+      "default": "10s"
+    }
+  },
+
+  "additionalProperties": false,
+
+  "examples": [
+    {
+      "tick": "100ms",
+      "parallelism": 4,
+      "ackPersists": true,
+      "validationTimeout": "60s"
+    },
+    {
+      "tick": "1s",
+      "parallelism": 8
+    },
+    {
+      "ackPersists": true,
+      "validationTimeout": "2m"
+    }
+  ]
+}

--- a/simulation/schema/defs/entity-id.json
+++ b/simulation/schema/defs/entity-id.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/entity-id.json",
+  "title": "Entity id settings",
+  "description": "Configuration for entity access patterns in the simulation",
+  "$comment": "Controls how entities are selected for activities, including their distribution across slices",
+
+  "type": "object",
+  "required": ["entity"],
+  "properties": {
+    "entity": {
+      "$ref": "./sampler.json",
+      "description": "Sampler settings for selecting entities"
+    },
+    "slices": {
+      "$ref": "./types.json#/definitions/intRange",
+      "description": "Optional range of slices that the entities are distributed over, otherwise all slices"
+    },
+    "sliceDistribution": {
+      "$ref": "./distribution-shape.json",
+      "description": "Optional distribution shape for assigning slices to entities, otherwise uniform"
+    }
+  },
+
+  "additionalProperties": false,
+
+  "examples": [
+    {
+      "entity": { "distribution": "uniform", "min": 1, "max": 8192 },
+      "slices": "0-63",
+      "sliceDistribution": { "type": "zipf", "exponent": 1.2, "shuffled": true }
+    },
+    {
+      "entity": {
+        "distribution": "log-normal",
+        "median": 2000,
+        "p95": 10000,
+        "min": 1,
+        "max": 16384
+      },
+      "slices": "0-127,256-383",
+      "sliceDistribution": { "type": "uniform" }
+    },
+    {
+      "entity": { "distribution": "uniform", "min": 1, "max": 4096 }
+    }
+  ]
+}

--- a/simulation/schema/defs/generator.json
+++ b/simulation/schema/defs/generator.json
@@ -1,0 +1,225 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/generator.json",
+  "title": "Generator settings",
+  "description": "Settings that control a specific workload generator's behavior",
+  "$comment": "Generators create realistic workload patterns by managing entity selection and activity generation",
+
+  "type": "object",
+  "required": ["entityId", "activity"],
+  "properties": {
+    "entityId": {
+      "$ref": "./entity-id.json",
+      "description": "Configuration for the entity access patterns"
+    },
+    "activity": {
+      "$ref": "./activity.json",
+      "description": "Configuration for the activity patterns"
+    },
+    "random": {
+      "$ref": "#/definitions/randomSettings",
+      "description": "Optional random number generator settings"
+    }
+  },
+
+  "additionalProperties": false,
+
+  "definitions": {
+    "randomSettings": {
+      "type": "object",
+      "description": "Configuration for random number generation",
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "description": "Optional random algorithm specification from Apache Commons RNG RandomSource enum",
+          "enum": [
+            "JDK",
+            "WELL_512_A",
+            "WELL_1024_A",
+            "WELL_19937_A",
+            "WELL_19937_C",
+            "WELL_44497_A",
+            "WELL_44497_B",
+            "MT",
+            "ISAAC",
+            "SPLIT_MIX_64",
+            "XOR_SHIFT_1024_S",
+            "TWO_CMRES",
+            "TWO_CMRES_SELECT",
+            "MWC_256",
+            "KISS",
+            "XOR_SHIFT_1024_S_PHI",
+            "XO_RO_SHI_RO_64_S",
+            "XO_RO_SHI_RO_64_SS",
+            "XO_SHI_RO_128_PLUS",
+            "XO_SHI_RO_128_SS",
+            "XO_SHI_RO_256_PLUS",
+            "XO_SHI_RO_256_SS",
+            "XO_SHI_RO_512_PLUS",
+            "XO_SHI_RO_512_SS",
+            "PCG_MCG_XSH_RR_32",
+            "PCG_MCG_XSH_RS_32",
+            "PCG_XSH_RR_32",
+            "PCG_XSH_RS_32",
+            "PCG_MCG_XSL_RR_64",
+            "PCG_MCG_XSL_RR_64_OS",
+            "PCG_XSL_RR_64",
+            "PCG_XSL_RR_64_OS",
+            "SFC_32",
+            "SFC_64",
+            "JSF_32",
+            "JSF_64",
+            "MSWS",
+            "LXM"
+          ],
+          "examples": [
+            "WELL_19937_C",
+            "MT",
+            "XO_SHI_RO_256_PLUS",
+            "PCG_XSL_RR_64",
+            "JSF_64"
+          ]
+        },
+        "seed": {
+          "type": "integer",
+          "description": "Optional seed value for deterministic randomization"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+
+  "examples": [
+    {
+      "entityId": {
+        "entity": { "distribution": "uniform", "min": 1, "max": 8192 },
+        "slices": "0-127"
+      },
+      "activity": {
+        "frequency": "5/s",
+        "duration": "3s",
+        "event": {
+          "frequency": "10/s",
+          "dataSize": "1kB"
+        }
+      }
+    },
+    {
+      "entityId": {
+        "entity": { "distribution": "uniform", "min": 1, "max": 8192 },
+        "slices": "0-63",
+        "sliceDistribution": { "type": "zipf", "exponent": 1.2 }
+      },
+      "activity": {
+        "frequency": {
+          "process": "poisson",
+          "rate": {
+            "function": "sinusoidal",
+            "base": "10/s",
+            "amplitude": "5/s",
+            "period": "60s"
+          }
+        },
+        "perSlice": {
+          "0-31": {
+            "perEntity": {
+              "*": {
+                "duration": {
+                  "distribution": "log-normal",
+                  "median": "2s",
+                  "p95": "10s"
+                },
+                "event": {
+                  "frequency": "10/s",
+                  "dataSize": {
+                    "distribution": "log-normal",
+                    "median": "512B",
+                    "p95": "2kB"
+                  }
+                }
+              }
+            }
+          },
+          "32-63": {
+            "perEntity": {
+              "0-1023": {
+                "duration": "5s",
+                "event": {
+                  "frequency": "20/s",
+                  "dataSize": "2kB"
+                }
+              },
+              "1024-4095": {
+                "duration": "2s",
+                "event": {
+                  "frequency": "5/s",
+                  "dataSize": "512B"
+                }
+              }
+            }
+          }
+        }
+      },
+      "random": {
+        "algorithm": "XO_SHI_RO_256_PLUS",
+        "seed": 12345
+      }
+    },
+    {
+      "entityId": {
+        "entity": { 
+          "distribution": "zipf",
+          "min": 1, 
+          "max": 1000, 
+          "exponent": 1.5,
+          "shuffled": true
+        }
+      },
+      "activity": {
+        "frequency": "2/s",
+        "perEntity": {
+          "0-1023": {
+            "duration": {
+              "distribution": "exponential",
+              "mean": "5s",
+              "min": "1s",
+              "max": "30s"
+            },
+            "event": {
+              "frequency": "20/s",
+              "dataSize": "2kB"
+            }
+          },
+          "1024-4095": {
+            "duration": {
+              "distribution": "weibull",
+              "scale": "5s",
+              "shape": 2.0
+            },
+            "event": {
+              "frequency": {
+                "process": "poisson",
+                "rate": {
+                  "function": "random-walk",
+                  "initial": "5/s",
+                  "min": "1/s",
+                  "max": "20/s",
+                  "volatility": 0.3
+                }
+              },
+              "dataSize": {
+                "distribution": "pareto",
+                "min": "256B",
+                "p95": "8kB"
+              }
+            }
+          }
+        }
+      },
+      "random": {
+        "algorithm": "WELL_19937_C",
+        "seed": 42
+      }
+    }
+  ]
+}

--- a/simulation/schema/defs/point-process.json
+++ b/simulation/schema/defs/point-process.json
@@ -1,0 +1,366 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/point-process.json",
+  "title": "Point process settings",
+  "description": "Settings that define the behavior of a point process (the occurrence of discrete events in continuous time)",
+  "$comment": "Point processes control event generation timing in the simulation",
+
+  "oneOf": [
+    {
+      "$ref": "./types.json#/definitions/rate",
+      "description": "Shorthand notation: a rate string directly creates a Poisson process with constant rate"
+    },
+    {
+      "$ref": "#/definitions/rateFunction",
+      "description": "Shorthand notation: a rate function object directly creates a Poisson process"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "process": {
+          "type": "string",
+          "enum": ["poisson"],
+          "default": "poisson",
+          "description": "Type of point process. Currently, only Poisson is supported"
+        },
+        "rate": {
+          "oneOf": [
+            {
+              "$ref": "./types.json#/definitions/rate",
+              "description": "Direct rate specification creates a constant rate function"
+            },
+            {
+              "$ref": "#/definitions/rateFunction",
+              "description": "Rate function that controls how event frequency changes over time"
+            }
+          ]
+        }
+      },
+      "required": ["rate"],
+      "additionalProperties": false
+    }
+  ],
+
+  "definitions": {
+    "rateFunction": {
+      "type": "object",
+      "properties": {
+        "function": {
+          "type": "string",
+          "enum": [
+            "constant",
+            "linear",
+            "sinusoidal",
+            "random-walk",
+            "burst",
+            "additive",
+            "modulated",
+            "composite"
+          ],
+          "description": "Type of rate function that controls how event frequency changes over time"
+        },
+        "value": {
+          "$ref": "./types.json#/definitions/rate",
+          "description": "The fixed rate at which events occur (for constant rate function)"
+        },
+        "initial": {
+          "$ref": "./types.json#/definitions/rate",
+          "description": "Initial rate for linear or random-walk rate functions"
+        },
+        "target": {
+          "$ref": "./types.json#/definitions/rate",
+          "description": "Target rate for linear rate function"
+        },
+        "base": {
+          "$ref": "./types.json#/definitions/rate",
+          "description": "Base rate for sinusoidal or burst rate functions"
+        },
+        "amplitude": {
+          "$ref": "./types.json#/definitions/rate",
+          "description": "Amplitude for sinusoidal rate function"
+        },
+        "period": {
+          "$ref": "./types.json#/definitions/duration",
+          "description": "Period for sinusoidal rate function"
+        },
+        "shift": {
+          "$ref": "./types.json#/definitions/duration",
+          "description": "Shift for sinusoidal rate function",
+          "default": "0s"
+        },
+        "min": {
+          "$ref": "./types.json#/definitions/rate",
+          "description": "Minimum rate for random-walk rate function"
+        },
+        "max": {
+          "$ref": "./types.json#/definitions/rate",
+          "description": "Maximum rate for random-walk rate function"
+        },
+        "volatility": {
+          "type": "number",
+          "exclusiveMinimum": 0,
+          "description": "Volatility for random-walk rate function"
+        },
+        "trend": {
+          "type": "number",
+          "description": "Trend for random-walk rate function",
+          "default": 0
+        },
+        "peak": {
+          "$ref": "./types.json#/definitions/rate",
+          "description": "Peak rate for burst rate function"
+        },
+        "start": {
+          "$ref": "./types.json#/definitions/duration",
+          "description": "Start time for burst rate function"
+        },
+        "rampUp": {
+          "$ref": "./types.json#/definitions/duration",
+          "description": "Ramp-up duration for burst rate function"
+        },
+        "burst": {
+          "$ref": "./types.json#/definitions/duration",
+          "description": "Burst duration for burst rate function"
+        },
+        "rampDown": {
+          "$ref": "./types.json#/definitions/duration",
+          "description": "Ramp-down duration for burst rate function"
+        },
+        "additiveRates": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Array of rate functions to be added together (for additive rate function)",
+          "items": {
+            "$ref": "#/definitions/rateFunction"
+          }
+        },
+        "carrier": {
+          "$ref": "#/definitions/rateFunction",
+          "description": "Rate function that serves as the carrier signal to be modulated"
+        },
+        "modulator": {
+          "$ref": "#/definitions/rateFunction",
+          "description": "Rate function that modulates the carrier signal"
+        },
+        "strength": {
+          "type": "number",
+          "description": "Optional strength parameter for modulation (for modulated rate function)"
+        },
+        "compositeRates": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Array of weighted rate functions (for composite rate function)",
+          "items": {
+            "type": "object",
+            "required": ["rate", "weight"],
+            "properties": {
+              "rate": {
+                "$ref": "#/definitions/rateFunction",
+                "description": "Rate function"
+              },
+              "weight": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "description": "Weight for this rate function"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["function"],
+      "allOf": [
+        {
+          "if": {
+            "properties": { "function": { "const": "constant" } }
+          },
+          "then": {
+            "required": ["value"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "function": { "const": "linear" } }
+          },
+          "then": {
+            "required": ["initial", "target"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "function": { "const": "sinusoidal" } }
+          },
+          "then": {
+            "required": ["base", "amplitude", "period"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "function": { "const": "random-walk" } }
+          },
+          "then": {
+            "required": ["initial", "min", "max", "volatility"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "function": { "const": "burst" } }
+          },
+          "then": {
+            "required": ["base", "peak", "start", "rampUp", "burst", "rampDown"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "function": { "const": "additive" } }
+          },
+          "then": {
+            "required": ["additiveRates"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "function": { "const": "modulated" } }
+          },
+          "then": {
+            "required": ["carrier", "modulator"]
+          }
+        },
+        {
+          "if": {
+            "properties": { "function": { "const": "composite" } }
+          },
+          "then": {
+            "required": ["compositeRates"]
+          }
+        }
+      ],
+      "additionalProperties": false
+    }
+  },
+
+  "examples": [
+    "10/s",
+    "0.5/ms",
+    "1000/min",
+    {
+      "function": "constant",
+      "value": "10/s"
+    },
+    {
+      "function": "linear",
+      "initial": "5/s",
+      "target": "50/s"
+    },
+    {
+      "process": "poisson",
+      "rate": "10/s"
+    },
+    {
+      "process": "poisson",
+      "rate": {
+        "function": "constant",
+        "value": "10/s"
+      }
+    },
+    {
+      "process": "poisson",
+      "rate": {
+        "function": "linear",
+        "initial": "5/s",
+        "target": "50/s"
+      }
+    },
+    {
+      "process": "poisson",
+      "rate": {
+        "function": "sinusoidal",
+        "base": "10/s",
+        "amplitude": "5/s",
+        "period": "30s"
+      }
+    },
+    {
+      "process": "poisson",
+      "rate": {
+        "function": "random-walk",
+        "initial": "10/s",
+        "min": "1/s",
+        "max": "20/s",
+        "volatility": 0.2,
+        "trend": 0.05
+      }
+    },
+    {
+      "process": "poisson",
+      "rate": {
+        "function": "burst",
+        "base": "5/s",
+        "peak": "100/s",
+        "start": "60s",
+        "rampUp": "10s",
+        "burst": "30s",
+        "rampDown": "20s"
+      }
+    },
+    {
+      "process": "poisson",
+      "rate": {
+        "function": "additive",
+        "rates": [
+          {
+            "function": "constant",
+            "value": "5/s"
+          },
+          {
+            "function": "sinusoidal",
+            "base": "10/s",
+            "amplitude": "3/s",
+            "period": "60s"
+          }
+        ]
+      }
+    },
+    {
+      "process": "poisson",
+      "rate": {
+        "function": "modulated",
+        "base": {
+          "function": "constant",
+          "value": "10/s"
+        },
+        "modulator": {
+          "function": "sinusoidal",
+          "base": "1.0",
+          "amplitude": "0.5",
+          "period": "120s"
+        },
+        "strength": 0.8
+      }
+    },
+    {
+      "process": "poisson",
+      "rate": {
+        "function": "composite",
+        "weighted": [
+          {
+            "function": {
+              "function": "constant",
+              "value": "5/s"
+            },
+            "weight": 0.7
+          },
+          {
+            "function": {
+              "function": "sinusoidal",
+              "base": "15/s",
+              "amplitude": "5/s",
+              "period": "30s"
+            },
+            "weight": 0.3
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/simulation/schema/defs/sampler.json
+++ b/simulation/schema/defs/sampler.json
@@ -1,0 +1,293 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/sampler.json",
+  "title": "Sampler settings",
+  "description": "Settings that define how values are sampled from various probability distributions",
+  "$comment": "Samplers can be provided either as a direct value (constant sampler) or as distribution configuration",
+
+  "oneOf": [
+    {
+      "$ref": "./types.json#/definitions/valueType",
+      "description": "Direct value creates a constant sampler"
+    },
+    {
+      "type": "object",
+      "properties": {
+        "count": {
+          "oneOf": [
+            { "type": "integer", "minimum": 1 },
+            { "$ref": "./types.json#/definitions/count" }
+          ],
+          "description": "Shorthand for uniform distribution from 1 to count (for discrete types only)"
+        },
+        "distribution": {
+          "type": "string",
+          "enum": [
+            "constant",
+            "uniform",
+            "incremental",
+            "zipf",
+            "exponential",
+            "weibull",
+            "gamma",
+            "log-normal",
+            "pareto",
+            "categorical",
+            "composite"
+          ],
+          "description": "Type of distribution sampler"
+        },
+        "value": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "The fixed value that will always be returned (for constant distribution)"
+        },
+        "min": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "Minimum value for ranges or bounds (for uniform, zipf, exponential, etc.)"
+        },
+        "max": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "Maximum value for ranges or bounds (for uniform, zipf, exponential, etc.)"
+        },
+        "start": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "The starting value for the counter (for incremental distribution)"
+        },
+        "step": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "The step value by which the counter is incremented (for incremental distribution)"
+        },
+        "limit": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "Optional limit value for cycling (for incremental distribution)"
+        },
+        "exponent": {
+          "type": "number",
+          "minimum": 0.1,
+          "description": "Controls the steepness of the distribution (for zipf distribution)"
+        },
+        "shuffled": {
+          "type": "boolean",
+          "description": "Whether to shuffle the distribution to randomize values while preserving frequency distribution. Most meaningful for distributions with unequal probabilities (like zipf, exponential, etc.)."
+        },
+        "mean": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "The mean (average) value (for exponential distribution)"
+        },
+        "shape": {
+          "type": "number",
+          "minimum": 0.1,
+          "description": "Shape parameter that determines the distribution's behavior (for weibull, gamma, log-normal, pareto)"
+        },
+        "scale": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "Scale parameter that determines the characteristic scale (for weibull, gamma, log-normal)"
+        },
+        "mu": {
+          "type": "number",
+          "description": "Location parameter (mean in log-space) (for log-normal distribution)"
+        },
+        "sigma": {
+          "type": "number",
+          "minimum": 0.001,
+          "description": "Shape parameter (standard deviation in log-space) (for log-normal distribution)"
+        },
+        "stdDev": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "Standard deviation for the distribution (for log-normal distribution)"
+        },
+        "median": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "Median value (50th percentile) (for log-normal, pareto distributions)"
+        },
+        "p95": {
+          "$ref": "./types.json#/definitions/valueType",
+          "description": "95th percentile value (for log-normal, pareto distributions)"
+        },
+        "categories": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Categories for categorical sampler",
+          "items": {
+            "type": "object",
+            "required": ["value", "weight"],
+            "properties": {
+              "value": {
+                "$ref": "./types.json#/definitions/valueType",
+                "description": "Value of the category"
+              },
+              "weight": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "description": "Weight of the category (relative probability)"
+              }
+            },
+            "additionalProperties": false
+          }
+        },
+        "samplers": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Samplers for composite sampler",
+          "items": {
+            "type": "object",
+            "required": ["sampler", "weight"],
+            "properties": {
+              "sampler": {
+                "$ref": "#",
+                "description": "Sampler settings"
+              },
+              "weight": {
+                "type": "number",
+                "exclusiveMinimum": 0,
+                "description": "Weight of the sampler (relative probability)"
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "oneOf": [
+        { "required": ["count"] },
+        { "required": ["distribution"] }
+      ],
+      "additionalProperties": false,
+
+      "allOf": [
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "constant" } }
+          },
+          "then": {
+            "required": ["value"]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "uniform" } }
+          },
+          "then": {
+            "required": ["min", "max"]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "incremental" } }
+          },
+          "then": {
+            "required": ["start", "step"]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "zipf" } }
+          },
+          "then": {
+            "required": ["min", "max", "exponent"]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "exponential" } }
+          },
+          "then": {
+            "required": ["mean"]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "weibull" } }
+          },
+          "then": {
+            "required": ["shape", "scale"]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "gamma" } }
+          },
+          "then": {
+            "required": ["shape", "scale"]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "log-normal" } }
+          },
+          "then": {
+            "oneOf": [
+              { "required": ["mu", "sigma"] },
+              { "required": ["scale", "shape"] },
+              { "required": ["mean", "stdDev"] },
+              { "required": ["median", "p95"] }
+            ]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "pareto" } }
+          },
+          "then": {
+            "oneOf": [
+              { "required": ["scale", "shape"] },
+              { "required": ["min", "p95"] }
+            ]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "categorical" } }
+          },
+          "then": {
+            "required": ["categories"]
+          }
+        },
+        {
+          "if": {
+            "required": ["distribution"],
+            "properties": { "distribution": { "const": "composite" } }
+          },
+          "then": {
+            "required": ["samplers"]
+          }
+        }
+      ]
+    }
+  ],
+
+  "examples": [
+    100,
+    "5s",
+    "10kB",
+    { "count": 100 },
+    { "count": "10k" },
+    { "distribution": "constant", "value": 100 },
+    { "distribution": "uniform", "min": 10, "max": 100 },
+    { "distribution": "incremental", "start": 1, "step": 1, "limit": 1000 },
+    {
+      "distribution": "zipf",
+      "min": 1,
+      "max": 1000,
+      "exponent": 1.2,
+      "shuffled": true
+    },
+    {
+      "distribution": "exponential",
+      "mean": "500ms",
+      "min": "10ms",
+      "max": "5s"
+    },
+    { "distribution": "log-normal", "median": "100ms", "p95": "500ms" },
+    { "distribution": "pareto", "min": 10, "p95": 1000 }
+  ]
+}

--- a/simulation/schema/defs/simulation.json
+++ b/simulation/schema/defs/simulation.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/simulation.json",
+  "title": "Simulation settings",
+  "description": "Main settings for a simulation configuration",
+  "$comment": "The simulation configuration defines a complete workload scenario with multiple sequential stages",
+
+  "type": "object",
+  "required": ["stages"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Optional name for the simulation for identification. Useful for distinguishing between different simulation runs"
+    },
+    "description": {
+      "type": "string",
+      "description": "Optional description for the simulation. Can provide context, purpose, or details about the simulated scenario"
+    },
+    "stages": {
+      "type": "array",
+      "description": "Sequence of stage configurations that will be executed sequentially",
+      "items": {
+        "$ref": "./stage.json"
+      },
+      "minItems": 1
+    },
+    "engine": {
+      "description": "Optional settings for the simulation execution engine",
+      "$ref": "./engine.json"
+    }
+  },
+
+  "additionalProperties": false
+}

--- a/simulation/schema/defs/stage.json
+++ b/simulation/schema/defs/stage.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/stage.json",
+  "title": "Stage settings",
+  "description": "Settings for a simulation stage. Stages are executed sequentially in the order they are defined.",
+  "$comment": "Each stage represents a distinct phase of the simulation with its own workload characteristics",
+
+  "type": "object",
+  "required": ["duration", "generators"],
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Optional name for this stage for identification"
+    },
+    "duration": {
+      "$ref": "./types.json#/definitions/duration",
+      "description": "Total runtime for this stage"
+    },
+    "delay": {
+      "$ref": "./types.json#/definitions/duration",
+      "description": "Optional delay before this stage starts (relative to the end of the previous stage)"
+    },
+    "generators": {
+      "type": "array",
+      "description": "Generator configurations controlling workload creation for this stage",
+      "items": {
+        "$ref": "./generator.json"
+      },
+      "minItems": 1
+    }
+  },
+
+  "additionalProperties": false,
+
+  "examples": [
+    {
+      "name": "warmup",
+      "duration": "2m",
+      "generators": [
+        {
+          "entityId": {
+            "selection": "slice-first",
+            "slice": { "distribution": "uniform", "min": 0, "max": 127 },
+            "entitiesPerSlice": 32
+          },
+          "activity": {
+            "frequency": "5/s",
+            "duration": "3s",
+            "event": {
+              "frequency": "10/s",
+              "dataSize": "1kB"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "steady-state",
+      "duration": "10m",
+      "delay": "30s",
+      "generators": [
+        {
+          "entityId": {
+            "selection": "slice-first",
+            "slice": { "distribution": "uniform", "min": 0, "max": 63 },
+            "entitiesPerSlice": 128,
+            "distribution": {
+              "type": "zipf",
+              "exponent": 1.2,
+              "shuffled": true
+            }
+          },
+          "activity": {
+            "frequency": "20/s",
+            "duration": {
+              "distribution": "log-normal",
+              "median": "5s",
+              "p95": "15s"
+            },
+            "event": {
+              "frequency": {
+                "process": "poisson",
+                "rate": {
+                  "type": "random-walk",
+                  "initial": "10/s",
+                  "min": "5/s",
+                  "max": "15/s",
+                  "volatility": 0.2
+                }
+              },
+              "dataSize": {
+                "distribution": "log-normal",
+                "median": "2kB",
+                "p95": "8kB"
+              }
+            }
+          }
+        },
+        {
+          "entityId": {
+            "selection": "entity-first",
+            "entity": {
+              "distribution": "zipf",
+              "min": 1,
+              "max": 1024,
+              "exponent": 1.5,
+              "shuffled": false
+            },
+            "slices": "64-127"
+          },
+          "activity": {
+            "frequency": "5/s",
+            "duration": "10s",
+            "event": {
+              "frequency": "2/s",
+              "dataSize": "4kB"
+            }
+          },
+          "random": {
+            "algorithm": "XO_SHI_RO_256_PLUS",
+            "seed": 12345
+          }
+        }
+      ]
+    },
+    {
+      "name": "spike",
+      "duration": "5m",
+      "generators": [
+        {
+          "entityId": {
+            "selection": "slice-first",
+            "slice": { "distribution": "uniform", "min": 0, "max": 127 },
+            "entitiesPerSlice": 64
+          },
+          "activity": {
+            "frequency": {
+              "process": "poisson",
+              "rate": {
+                "type": "burst",
+                "base": "10/s",
+                "peak": "100/s",
+                "start": "1m",
+                "rampUp": "30s",
+                "burst": "2m",
+                "rampDown": "1m"
+              }
+            },
+            "duration": "5s",
+            "event": {
+              "frequency": "20/s",
+              "dataSize": "1kB"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/simulation/schema/defs/types.json
+++ b/simulation/schema/defs/types.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/defs/types.json",
+  "title": "Common types",
+  "description": "Common type definitions used throughout the simulation schema",
+  "$comment": "These type definitions represent core value types with specific formats for the simulation framework",
+  "definitions": {
+    "duration": {
+      "type": "string",
+      "description": "Represents a duration with a time unit. Examples: '5s', '10ms', '1h'",
+      "pattern": "^\\d+(?:\\.\\d+)?\\s*(ns|nanos?|nanoseconds?|μs|micros?|microseconds?|ms|millis?|milliseconds?|s|secs?|seconds?|m|mins?|minutes?|h|hr?|hours?|d|days?)$",
+      "examples": ["5s", "100ms", "1.5h", "500ns", "10min", "1d"]
+    },
+    "optionalDuration": {
+      "anyOf": [{ "$ref": "#/definitions/duration" }, { "type": "null" }],
+      "description": "An optional duration value"
+    },
+    "count": {
+      "type": "string",
+      "description": "Represents a count, possibly with a unit multiplier (k=1000, M=1000000, G=1000000000)",
+      "pattern": "^\\d+(?:\\.\\d+)?\\s*([kMG]?)$",
+      "examples": ["100", "5k", "1.5M", "2G"]
+    },
+    "dataSize": {
+      "type": "string",
+      "description": "Represents a data size with binary or decimal units",
+      "pattern": "^\\d+(?:\\.\\d+)?\\s*(B|kB|MB|GB|KiB|MiB|GiB)$",
+      "examples": ["512B", "10kB", "1.5MB", "2GiB", "128KiB"]
+    },
+    "rate": {
+      "type": "string",
+      "description": "Rate per time unit. Examples: '10/s', '100/min'",
+      "pattern": "^\\d+(?:\\.\\d+)?\\s*/\\s*(ns|nanos?|nanoseconds?|μs|micros?|microseconds?|ms|millis?|milliseconds?|s|secs?|seconds?|mins?|minutes?|h|hr?|hours?|d|days?)$",
+      "examples": ["10/s", "1000/min", "0.5/ms", "5/h", "0.1/μs"]
+    },
+    "positiveNumber": {
+      "type": "number",
+      "exclusiveMinimum": 0,
+      "description": "A positive number value (greater than zero)"
+    },
+    "nonNegativeNumber": {
+      "type": "number",
+      "minimum": 0,
+      "description": "A non-negative number value (zero or greater)"
+    },
+    "positiveInteger": {
+      "type": "integer",
+      "exclusiveMinimum": 0,
+      "description": "A positive integer value (greater than zero)"
+    },
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "A non-negative integer value (zero or greater)"
+    },
+    "valueType": {
+      "oneOf": [
+        { "type": "integer" },
+        { "$ref": "#/definitions/duration" },
+        { "$ref": "#/definitions/dataSize" },
+        { "$ref": "#/definitions/count" }
+      ],
+      "description": "A value of one of the supported types: integer, duration, data size, or count"
+    },
+    "intRange": {
+      "type": "string",
+      "pattern": "^\\*|\\d+(-\\d+)?(,\\d+(-\\d+)?)*$",
+      "description": "Defines a range of integers. Can be a single value, a range (e.g., 1-5), or multiple ranges separated by commas (e.g., 1-5,10-15). '*' represents the default range (all values).",
+      "examples": ["*", "5", "1-10", "1-5,10-15", "3,7-9,15-20"]
+    },
+    "probability": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1,
+      "description": "A probability value between 0 and 1 inclusive"
+    },
+    "seed": {
+      "type": "integer",
+      "description": "Seed value for random number generators to ensure reproducibility"
+    }
+  }
+}

--- a/simulation/schema/run-simulation.json
+++ b/simulation/schema/run-simulation.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://akka.io/schemas/projection-testing/run-simulation.json",
+  "title": "Run Simulation",
+  "description": "Schema for configuring simulation runs in the Akka Projection Testing framework",
+  "$comment": "This schema defines the input format for the /simulation/run API endpoint",
+
+  "type": "object",
+  "required": ["simulation"],
+  "properties": {
+    "simulation": {
+      "$ref": "./defs/simulation.json",
+      "description": "The simulation configuration to execute"
+    },
+    "resetBeforeRun": {
+      "type": "boolean",
+      "description": "Whether to reset the database before running the simulation. If omitted, defaults to true",
+      "default": true
+    }
+  }
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,6 +1,8 @@
 akka.http.server.request-timeout = 600 s
 
 akka {
+  license-key = ${?AKKA_LICENSE_KEY}
+
   loglevel = DEBUG
 
   actor {
@@ -20,7 +22,7 @@ akka {
   cluster {
     downing-provider-class = "akka.cluster.sbr.SplitBrainResolverProvider"
 
-    roles = ["write-model", "read-model"]
+    roles = ["engine", "write-model", "read-model"]
 
     sharding {
       least-shard-allocation-strategy  {
@@ -119,9 +121,20 @@ test {
 # cinnamon
 cinnamon.prometheus {
   exporters += http-server
+
+  summary {
+    # for scrape frequency of 10s
+    max-age = 20s
+    age-buckets = 2
+    significant-value-digits = 3
+  }
 }
 
 cinnamon.akka {
+  projection.metrics {
+    envelope-sources = on
+  }
+
   persistence.entities {
     // sharded:? will expand to /system/sharding/?/*
     "sharded:?" {

--- a/src/main/resources/local-shared.conf
+++ b/src/main/resources/local-shared.conf
@@ -5,7 +5,7 @@ akka {
       "akka://test@127.0.0.1:2552"
     ]
 
-    roles = ["write-model", "read-model"]
+    roles = ["engine", "write-model", "read-model"]
   }
 
   # For the sample, just bind to loopback and do not allow access from the network

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -9,6 +9,7 @@
     <logger name="com.datastax.oss.driver" level="WARN"/>
     <logger name="com.codahale.metrics" level="INFO"/>
 
+<!--    <logger name="akka.projection.testing" level="DEBUG" /> -->
 <!--    <logger name="akka.persistence.r2dbc" level="DEBUG" />-->
 <!--    <logger name="akka.projection.r2dbc" level="DEBUG" />-->
 <!--    <logger name="io.r2dbc.postgresql.QUERY" level="DEBUG" />-->

--- a/src/main/resources/r2dbc.conf
+++ b/src/main/resources/r2dbc.conf
@@ -18,6 +18,13 @@ akka.persistence.r2dbc {
     password = "postgres"
     password = ${?DB_PASSWORD}
     max-size = 50
+
+    ssl {
+      enabled = off
+      enabled = ${?DB_SSL_ENABLED}
+      mode = "require"
+      mode = ${?DB_SSL_MODE}
+    }
   }
 
   query {

--- a/src/main/scala/akka/projection/testing/LoadGeneration.scala
+++ b/src/main/scala/akka/projection/testing/LoadGeneration.scala
@@ -18,7 +18,6 @@ import akka.actor.Scheduler
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
-import akka.actor.typed.DispatcherSelector
 import akka.actor.typed.Terminated
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter.TypedActorSystemOps
@@ -63,7 +62,7 @@ object LoadGeneration {
       case ActivateActors(testName, actors) =>
         (1 to actors).foreach { n =>
           val pid = s"${testName}-$n"
-          shardRegion ! ShardingEnvelope(pid, ConfigurablePersistentActor.WakeUp(testName))
+          shardRegion ! ShardingEnvelope(pid, ConfigurablePersistentActor.WakeUp)
         }
         Behaviors.same
     }
@@ -166,8 +165,7 @@ object LoadTest {
                   total / math.max(totalTime.nanos.toSeconds, 1))
                 val validation = ctx.spawn(
                   TestValidation(testName, settings.nrProjections, expected, t.seconds, setup),
-                  s"TestValidation=$testName",
-                  DispatcherSelector.blocking())
+                  s"TestValidation=$testName")
                 ctx.watch(validation)
                 Behaviors.same
               }

--- a/src/main/scala/akka/projection/testing/TestRoutes.scala
+++ b/src/main/scala/akka/projection/testing/TestRoutes.scala
@@ -4,42 +4,67 @@
 
 package akka.projection.testing
 
+import java.util.UUID
+
+import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.Failure
 import scala.util.Success
 
+import akka.Done
 import akka.actor.typed.ActorRef
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.AskPattern._
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.projection.testing.simulation.Engine
+import akka.projection.testing.simulation.SimulationJsonFormat
+import akka.projection.testing.simulation.SimulationSettings
 import akka.util.Timeout
 import org.slf4j.LoggerFactory
-import spray.json.DefaultJsonProtocol._
 import spray.json.RootJsonFormat
 
 object TestRoutes {
+  import SimulationJsonFormat._
 
-  case class RunTest(
-      name: String,
+  final case class RunTest(
+      name: Option[String],
       nrActors: Int,
       messagesPerActor: Int,
       bytesPerEvent: Int,
       concurrentActors: Int,
       timeout: Int)
 
-  case class ActivateActors(name: String, nrActors: Int)
+  final case class ActivateTestActors(name: String, nrActors: Int)
 
-  case class Response(testName: String, expectedMessages: Long)
+  final case class RunTestResponse(testName: String, expectedMessages: Long)
+
+  final case class RunSimulation(simulation: SimulationSettings, resetBeforeRun: Option[Boolean])
+
+  final case class RunSimulationResponse(runId: String)
+
+  final case class ActivateSimulationEntities(minSlice: Int, maxSlice: Int, minEntity: Int, maxEntity: Int)
+
+  final case class PassivateSimulationEntities(minSlice: Int, maxSlice: Int, minEntity: Int, maxEntity: Int)
 
   implicit val runTestFormat: RootJsonFormat[RunTest] = jsonFormat6(RunTest)
-  implicit val activateActorsFormat: RootJsonFormat[ActivateActors] = jsonFormat2(ActivateActors)
-  implicit val testResultFormat: RootJsonFormat[Response] = jsonFormat2(Response)
+  implicit val activateTestActorsFormat: RootJsonFormat[ActivateTestActors] = jsonFormat2(ActivateTestActors)
+  implicit val runTestResponseFormat: RootJsonFormat[RunTestResponse] = jsonFormat2(RunTestResponse)
+
+  implicit val runSimulationFormat: RootJsonFormat[RunSimulation] = jsonFormat2(RunSimulation)
+  implicit val runSimulationResponseFormat: RootJsonFormat[RunSimulationResponse] = jsonFormat1(RunSimulationResponse)
+  implicit val activateSimulationEntitiesFormat: RootJsonFormat[ActivateSimulationEntities] =
+    jsonFormat4(ActivateSimulationEntities)
+  implicit val passivateSimulationEntitiesFormat: RootJsonFormat[PassivateSimulationEntities] =
+    jsonFormat4(PassivateSimulationEntities)
 }
 
-class TestRoutes(loadGeneration: ActorRef[LoadGeneration.Command], setup: TestSetup)(implicit
-    val system: ActorSystem[_]) {
+class TestRoutes(
+    loadGeneration: ActorRef[LoadGeneration.Command],
+    simulationEngine: ActorRef[Engine.Command],
+    setup: TestSetup)(implicit val system: ActorSystem[_]) {
 
   private val log = LoggerFactory.getLogger(classOf[TestRoutes])
 
@@ -57,8 +82,7 @@ class TestRoutes(loadGeneration: ActorRef[LoadGeneration.Command], setup: TestSe
         path("test") {
           entity(as[RunTest]) { runTest =>
             implicit val timeout: Timeout = Timeout(60.seconds)
-            import akka.actor.typed.scaladsl.AskPattern._
-            val name = if (runTest.name.isBlank) s"test-${System.currentTimeMillis()}" else runTest.name
+            val name = runTest.name.getOrElse(s"test-${System.currentTimeMillis()}")
             log.info("Starting test run [{}] ...", name)
 
             val test = for {
@@ -79,7 +103,7 @@ class TestRoutes(loadGeneration: ActorRef[LoadGeneration.Command], setup: TestSe
 
             onComplete(test) {
               case Success(summary) =>
-                complete(Response(summary.name, summary.expectedMessages))
+                complete(RunTestResponse(summary.name, summary.expectedMessages))
               case Failure(t) =>
                 complete(StatusCodes.InternalServerError, s"test failed to start: " + t.getMessage)
             }
@@ -88,9 +112,70 @@ class TestRoutes(loadGeneration: ActorRef[LoadGeneration.Command], setup: TestSe
       },
       post {
         path("activate") {
-          entity(as[ActivateActors]) { activateActors =>
+          entity(as[ActivateTestActors]) { activateActors =>
             loadGeneration ! LoadGeneration.ActivateActors(activateActors.name, activateActors.nrActors)
             complete(StatusCodes.Accepted)
+          }
+        }
+      },
+      post {
+        path("simulation" / "run") {
+          entity(as[RunSimulation]) { run =>
+            val runId = UUID.randomUUID().toString
+            log.info("Running simulation [{}] ...", runId)
+
+            val reset = run.resetBeforeRun.getOrElse(true)
+
+            val started =
+              for {
+                _ <- if (reset) setup.reset() else Future.successful(Done)
+                response <- {
+                  log.info("Starting simulation [{}] {} ...", runId, if (reset) "(after reset)" else "(without reset)")
+                  implicit val timeout: Timeout = Timeout(10.seconds)
+                  simulationEngine.askWithStatus[Engine.Response](replyTo =>
+                    Engine.RunSimulation(runId, run.simulation, replyTo))
+                }
+              } yield response
+
+            onComplete(started) {
+              case Success(_) =>
+                complete(RunSimulationResponse(runId))
+              case Failure(error) =>
+                complete(StatusCodes.InternalServerError, s"Simulation [$runId] failed to start: " + error.getMessage)
+            }
+          }
+        }
+      },
+      get {
+        pathPrefix("simulation" / "status" / Segment) { name =>
+          complete(setup.readResult(name))
+        }
+      },
+      post {
+        path("simulation" / "activate") {
+          entity(as[ActivateSimulationEntities]) {
+            case ActivateSimulationEntities(minSlice, maxSlice, minEntity, maxEntity) =>
+              simulationEngine ! Engine.TellSimulationEntities(
+                minSlice,
+                maxSlice,
+                minEntity,
+                maxEntity,
+                ConfigurablePersistentActor.WakeUp)
+              complete(StatusCodes.Accepted)
+          }
+        }
+      },
+      post {
+        path("simulation" / "passivate") {
+          entity(as[PassivateSimulationEntities]) {
+            case PassivateSimulationEntities(minSlice, maxSlice, minEntity, maxEntity) =>
+              simulationEngine ! Engine.TellSimulationEntities(
+                minSlice,
+                maxSlice,
+                minEntity,
+                maxEntity,
+                ConfigurablePersistentActor.Stop)
+              complete(StatusCodes.Accepted)
           }
         }
       })

--- a/src/main/scala/akka/projection/testing/simulation/Engine.scala
+++ b/src/main/scala/akka/projection/testing/simulation/Engine.scala
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Failure
+import scala.util.Success
+
+import akka.Done
+import akka.actor.typed.ActorRef
+import akka.actor.typed.ActorSystem
+import akka.actor.typed.Behavior
+import akka.actor.typed.Terminated
+import akka.actor.typed.scaladsl.AskPattern._
+import akka.actor.typed.scaladsl.Behaviors
+import akka.cluster.sharding.typed.ShardingEnvelope
+import akka.pattern.StatusReply
+import akka.projection.testing.ConfigurablePersistentActor
+import akka.projection.testing.EventProcessorSettings
+import akka.projection.testing.TestSetup
+import akka.projection.testing.TestValidation
+import akka.stream.scaladsl.Source
+import akka.util.PrettyDuration
+import akka.util.Timeout
+import org.slf4j.Logger
+
+object Engine {
+
+  sealed trait Command
+  sealed trait Response
+
+  final case class RunSimulation(runId: String, settings: SimulationSettings, replyTo: ActorRef[StatusReply[Response]])
+      extends Command
+
+  case object SimulationStarted extends Response
+
+  final case class TellSimulationEntities(
+      minSlice: Int,
+      maxSlice: Int,
+      minEntity: Int,
+      maxEntity: Int,
+      command: ConfigurablePersistentActor.Command)
+      extends Command
+
+  object Settings {
+    def tick(settings: Option[EngineSettings]): FiniteDuration =
+      settings.flatMap(_.tick).getOrElse(200.millis)
+
+    def parallelism(settings: Option[EngineSettings]): Int =
+      settings.flatMap(_.parallelism).getOrElse(4)
+
+    def ackPersists(settings: Option[EngineSettings]): Boolean =
+      settings.flatMap(_.ackPersists).getOrElse(false)
+
+    def validationTimeout(settings: Option[EngineSettings]): FiniteDuration =
+      settings.flatMap(_.validationTimeout).getOrElse(10.seconds)
+  }
+
+  def apply(
+      processorSettings: EventProcessorSettings,
+      shardedEntity: ActorRef[ShardingEnvelope[ConfigurablePersistentActor.Command]],
+      setup: TestSetup): Behavior[Command] =
+    Behaviors.setup { context =>
+      Behaviors.receiveMessage[Command] {
+        case RunSimulation(runId, settings, replyTo) =>
+          import context.system
+          val persist: Event => Future[Done] =
+            if (Settings.ackPersists(settings.engine)) persistEventWithAck(runId, shardedEntity)
+            else persistEvent(runId, shardedEntity)
+          context.spawn(Runner(processorSettings, persist, setup), s"runner-$runId") ! Runner.Start(runId, settings)
+          replyTo ! StatusReply.success(SimulationStarted)
+          Behaviors.same
+
+        case TellSimulationEntities(minSlice, maxSlice, minEntity, maxEntity, command) =>
+          val entityType = ConfigurablePersistentActor.Key.name
+          for (slice <- minSlice to maxSlice; entity <- minEntity to maxEntity) {
+            val entityId = EntityId.create(entityType, Slice(slice), entity)
+            shardedEntity ! ShardingEnvelope(entityId.toString, command)
+          }
+          Behaviors.same
+      }
+    }
+
+  private def persistEvent(
+      testName: String,
+      shardedEntity: ActorRef[ShardingEnvelope[ConfigurablePersistentActor.Command]])(event: Event): Future[Done] = {
+    shardedEntity ! ShardingEnvelope(
+      event.activity.entityId.toString,
+      ConfigurablePersistentActor.PersistSingle(testName, event.identifier, event.dataBytes))
+    Future.successful(Done)
+  }
+
+  private def persistEventWithAck(
+      testName: String,
+      entity: ActorRef[ShardingEnvelope[ConfigurablePersistentActor.Command]])(event: Event)(implicit
+      system: ActorSystem[_]): Future[Done] = {
+    implicit val timeout: Timeout = 1.second
+    entity.askWithStatus[Done] { replyTo =>
+      ShardingEnvelope(
+        event.activity.entityId.toString,
+        ConfigurablePersistentActor.PersistSingleAndAck(testName, event.identifier, event.dataBytes, replyTo))
+    }
+  }
+}
+
+object Runner {
+
+  sealed trait Command
+
+  final case class Start(runId: String, settings: SimulationSettings) extends Command
+
+  final case class Summary(totalActivities: Long, totalEvents: Long)
+
+  object Summary {
+    val Empty = Summary(0L, 0L)
+  }
+
+  final case class Validate(summary: Summary) extends Command
+
+  final case class Fail(error: Throwable) extends Command
+
+  def apply(
+      processorSettings: EventProcessorSettings,
+      persist: Event => Future[Done],
+      setup: TestSetup): Behavior[Command] =
+    Behaviors.setup { context =>
+      context.setLoggerName(Runner.getClass)
+
+      Behaviors.receiveMessagePartial[Command] { case Start(runId, settings) =>
+        val startTime = System.nanoTime()
+        val summary = run(runId, settings, persist, context.log)(context.system)
+
+        context.pipeToSelf(summary) {
+          case Success(summary) => Validate(summary)
+          case Failure(error)   => Fail(error)
+        }
+
+        Behaviors
+          .receiveMessagePartial[Command] {
+            case Validate(Summary(totalActivities, totalEvents)) =>
+              val finishTime = System.nanoTime()
+              val totalTime = finishTime - startTime
+              context.log.info(
+                "Simulation completed in: {}. Total activities: {}. Total events: {}. Averages: {} activities/s, {} events/activity, {} events/s.",
+                PrettyDuration.format(totalTime.nanos),
+                totalActivities,
+                totalEvents,
+                totalActivities / math.max(totalTime.nanos.toSeconds, 1),
+                totalEvents / totalActivities,
+                totalEvents / math.max(totalTime.nanos.toSeconds, 1))
+              if (processorSettings.readOnly) {
+                context.log.info("No validation (read-only)")
+                Behaviors.stopped
+              } else {
+                context.log.info("Starting validation")
+                val validation = context.spawn(
+                  TestValidation(
+                    runId,
+                    processorSettings.nrProjections,
+                    totalEvents,
+                    Engine.Settings.validationTimeout(settings.engine),
+                    setup),
+                  s"validation-$runId")
+                context.watch(validation)
+                Behaviors.same
+              }
+            case Fail(error) =>
+              context.log.error("Simulation failed", error)
+              Behaviors.stopped
+          }
+          .receiveSignal { case (signalContext, Terminated(_)) =>
+            signalContext.log.info("Validation completed")
+            Behaviors.stopped
+          }
+      }
+    }
+
+  def run(id: String, settings: SimulationSettings, process: Event => Future[Done], log: Logger)(implicit
+      system: ActorSystem[_]): Future[Summary] = {
+    implicit val ec = system.executionContext
+    val generator = SimulationGenerator(settings)
+    val tickInterval = Engine.Settings.tick(settings.engine)
+    val parallelism = Engine.Settings.parallelism(settings.engine)
+    val reportEvery = (5.seconds / tickInterval) * parallelism
+    val groupedEvents = Source.fromIterator(() => generator.groupedEvents(tickInterval))
+    val ticks = Source.tick(0.seconds, tickInterval, ())
+    val startTime = System.nanoTime()
+    ticks
+      .zip(groupedEvents)
+      .mapConcat { case (_, events) =>
+        events.groupBy(_.activity.id.seqNr % parallelism).values
+      }
+      .mapAsyncUnordered(parallelism) { group =>
+        Future.foldLeft(group.map(event => process(event).map(_ => event)(ExecutionContext.parasitic)))(Summary.Empty) {
+          case (Summary(totalActivities, totalEvents), event) =>
+            val newTotalActivities = if (event.seqNr == 1) totalActivities + 1 else totalActivities
+            val newTotalEvents = totalEvents + 1
+            Summary(newTotalActivities, newTotalEvents)
+        }
+      }
+      .runFold((0, Summary.Empty)) {
+        case ((totalGroups, Summary(totalActivities, totalEvents)), Summary(groupActivities, groupEvents)) =>
+          val newTotalActivities = totalActivities + groupActivities
+          val newTotalEvents = totalEvents + groupEvents
+          if (totalGroups % reportEvery == 0) {
+            val runningTime = System.nanoTime() - startTime
+            log.info(
+              "Generated {} events. Running time: {}. Average rate of {} events/s.",
+              newTotalEvents,
+              PrettyDuration.format(runningTime.nanos),
+              newTotalEvents / math.max(runningTime.nanos.toSeconds, 1))
+          }
+          (totalGroups + 1, Summary(newTotalActivities, newTotalEvents))
+      }
+      .map { case (_, summary) => summary }(ExecutionContext.parasitic)
+  }
+}

--- a/src/main/scala/akka/projection/testing/simulation/Generator.scala
+++ b/src/main/scala/akka/projection/testing/simulation/Generator.scala
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.collection.immutable.IntMap
+import scala.concurrent.duration._
+
+import akka.projection.testing.ConfigurablePersistentActor
+import org.apache.commons.rng.UniformRandomProvider
+import org.apache.commons.rng.simple.RandomSource
+
+final case class Activity(id: ActivityId, entityId: EntityId, start: Point, duration: Point)
+
+final case class Event(activity: Activity, seqNr: Int, point: Point, dataBytes: Int) {
+  def time: Point = activity.start + point
+  def identifier: String = s"${activity.id}-${activity.entityId}-$seqNr"
+}
+
+object Event {
+  implicit val ordering: Ordering[Event] = Ordering.by[Event, Point](_.time)
+}
+
+object SimulationGenerator {
+  def apply(settings: SimulationSettings): SimulationGenerator = {
+    val (_, stageGenerators) =
+      settings.stages.zipWithIndex.foldLeft((Duration.Zero, Seq.empty[StageGenerator])) {
+        case ((previousEndTime, generators), (stageSettings, index)) =>
+          val startTime = previousEndTime + stageSettings.delay.getOrElse(Duration.Zero)
+          val endTime = startTime + stageSettings.duration
+          val stageGenerator = StageGenerator(stageId = index + 1, startTime, stageSettings)
+          (endTime, generators :+ stageGenerator)
+      }
+    new SimulationGenerator(stageGenerators)
+  }
+}
+
+final class SimulationGenerator(generators: Seq[StageGenerator]) {
+  def events(): Iterator[Event] = {
+    new MergedIterator(generators.map(_.events()))
+  }
+
+  def groupedEvents(windowDuration: FiniteDuration): Iterator[Seq[Event]] = {
+    val window = Point(windowDuration)
+    val boundaries = Iterator.iterate(window)(_ + window)
+    new GroupedIterator(events(), boundaries, (event: Event) => event.time)
+  }
+}
+
+object StageGenerator {
+  def apply(stageId: Int, start: FiniteDuration, settings: StageSettings): StageGenerator = {
+    val generators = settings.generators.zipWithIndex.map { case (generatorSettings, index) =>
+      Generator(stageId, generatorId = index + 1, generatorSettings, start, settings.duration)
+    }
+    new StageGenerator(generators)
+  }
+}
+
+final class StageGenerator(generators: Seq[Generator]) {
+  def events(): Iterator[Event] = {
+    new MergedIterator(generators.map(_.events()))
+  }
+}
+
+object Generator {
+  def apply(
+      stageId: Int,
+      generatorId: Int,
+      settings: GeneratorSettings,
+      start: FiniteDuration,
+      duration: FiniteDuration): Generator = {
+    val baseRandom = RandomProvider(settings.random)
+    val random = baseRandom.expand(stageId, generatorId)
+    val activityGenerator =
+      ActivityGenerator(stageId, generatorId, start, duration, settings.entityId, settings.activity, baseRandom)
+    val eventSettings = EntityIdMap(settings.activity, _.event)
+    new Generator(
+      activityGenerator,
+      activity => ActivityEventGenerator(activity, eventSettings, random.expand(activity.id.seqNr)))
+  }
+}
+
+final class Generator(
+    activityGenerator: ActivityGenerator,
+    activityEventGenerator: Activity => ActivityEventGenerator) {
+
+  def events(): Iterator[Event] = {
+    val eventIterators = activityGenerator.activities().map(activity => activityEventGenerator(activity).events())
+    val mergedEventIterator = new FlatMergedIterator[Event](eventIterators)
+    mergedEventIterator.takeWhile(_.time < activityGenerator.maxPoint)
+  }
+}
+
+object ActivityGenerator {
+  def apply(
+      stageId: Int,
+      generatorId: Int,
+      start: FiniteDuration,
+      duration: FiniteDuration,
+      entityIdSettings: EntityIdSettings,
+      activitySettings: ActivitySettings,
+      baseRandom: RandomProvider): ActivityGenerator = {
+    // note: entity id's sampled with baseRandom (reproducible across stages and generators)
+    val random = baseRandom.expand(stageId, generatorId)
+    new ActivityGenerator(
+      stageId,
+      generatorId,
+      PointProcess(activitySettings.frequency, start, duration, random),
+      () => EntityIdSampler(entityIdSettings, baseRandom),
+      () => EntityIdMap(activitySettings, perEntitySettings => ContinuousSampler(perEntitySettings.duration, random)))
+  }
+}
+
+final class ActivityGenerator(
+    stageId: Int,
+    generatorId: Int,
+    activityStart: PointProcess,
+    createEntityIdSampler: () => EntityIdSampler,
+    createDurationSamplers: () => EntityIdMap[ContinuousSampler]) {
+
+  import IteratorExtensions._
+
+  def maxPoint: Point = activityStart.max
+
+  def activities(): Iterator[Activity] = {
+    val entityIdSampler = createEntityIdSampler()
+    val durationSampler = createDurationSamplers()
+    activityStart.points().zipWithSeqNr.map { case (start, seqNr) =>
+      val activityId = ActivityId(stageId, generatorId, seqNr)
+      val entityId = entityIdSampler.sample()
+      val duration = Point(durationSampler(entityId).sample())
+      Activity(activityId, entityId, start, duration)
+    }
+  }
+}
+
+object ActivityEventGenerator {
+  def apply(
+      activity: Activity,
+      eventSettings: EntityIdMap[EventSettings],
+      random: RandomProvider): ActivityEventGenerator = {
+    new ActivityEventGenerator(
+      activity,
+      PointProcess(eventSettings(activity.entityId).frequency, Point.Zero, activity.duration, random),
+      () => DiscreteSampler(eventSettings(activity.entityId).dataSize, random))
+  }
+}
+
+final class ActivityEventGenerator(
+    activity: Activity,
+    activityEvents: PointProcess,
+    createEventDataSizeSampler: () => DiscreteSampler) {
+  import IteratorExtensions._
+
+  // note: always start with an event at the beginning of the activity
+  def events(): Iterator[Event] = {
+    val eventDataSize = createEventDataSizeSampler()
+    Iterator.single(Point.Zero).concat(activityEvents.points()).zipWithSeqNr.map { case (point, seqNr) =>
+      Event(activity, seqNr, point, eventDataSize.sample())
+    }
+  }
+}
+
+final case class ActivityId(stage: Int, generator: Int, seqNr: Int) {
+  override def toString: String = s"$stage-$generator-$seqNr"
+}
+
+final case class EntityId(slice: Slice, entity: Int, suffix: String) {
+  override def toString: String = s"${slice.value}-$entity-$suffix"
+}
+
+object EntityId {
+  final case class IdSuffix(shift: Int, suffix: String, hash: Int)
+
+  private val (lowSuffixes, highSuffixes) = {
+    val chars = 'a' to 'z'
+    val suffixes =
+      for (c1 <- chars; c2 <- chars; c3 <- chars; suffix = s"$c1$c2$c3"; hash = suffix.hashCode)
+        yield IdSuffix(hash % 1024, suffix, hash)
+    val suffixesByShift = suffixes.groupBy(_.shift)
+    val lowSuffixes = suffixesByShift.map { case (shift, suffixes) => shift -> suffixes.minBy(_.hash) }.to(IntMap)
+    val highSuffixes = suffixesByShift.map { case (shift, suffixes) => shift -> suffixes.maxBy(_.hash) }.to(IntMap)
+    (lowSuffixes, highSuffixes)
+  }
+
+  // Utility for generating deterministic entity ids that map to specific slices.
+  // Does this by adding an appropriate suffix that will shift the hash of the persistence id to the desired slice.
+  // For example, `EntityId.create(entityType = "test", slice = Slice(123), entity = 42)` will return "123-42-alz",
+  // where `math.abs("test|123-42-alz".hashCode) % 1024` = 123.
+  def create(entityType: String, slice: Slice, entity: Int): EntityId = {
+    val baseEntityId = s"${slice.value}-$entity-"
+    val basePersistenceId = s"$entityType|$baseEntityId"
+    val baseHash = basePersistenceId.hashCode * 31 * 31 * 31 // suffixes are always 3 chars
+    val baseSlice = math.abs(baseHash) % 1024
+    val diff = (1024 + (slice.value - baseSlice)) % 1024
+    val shift = if (baseHash < 0) (1024 - diff) % 1024 else diff
+    val lowSuffix = lowSuffixes(shift)
+    val shiftedHash = baseHash + lowSuffix.hash
+    val entityId = if (differentSigns(baseHash, shiftedHash)) {
+      // shifted from negative to positive, or positive to negative (overflowed)
+      // need to use an "inverted" shift from the high suffixes
+      val invertedShift = (shift + 2 * (1024 + (if (shiftedHash < 0) -slice.value else slice.value))) % 1024
+      val highSuffix = highSuffixes(invertedShift)
+      EntityId(slice, entity, highSuffix.suffix)
+    } else {
+      EntityId(slice, entity, lowSuffix.suffix)
+    }
+    assert(
+      math.abs(s"$entityType|$entityId".hashCode) % 1024 == slice.value,
+      s"Generated entity id [$entityType|$entityId] is not for slice [$slice]")
+    entityId
+  }
+
+  private def differentSigns(a: Int, b: Int): Boolean = {
+    (a >= 0 && b < 0) || (a < 0 && b >= 0)
+  }
+}
+
+object EntityIdSampler {
+  private val entityType = ConfigurablePersistentActor.Key.name
+
+  def apply(settings: EntityIdSettings, random: RandomProvider): EntityIdSampler = {
+    val entitySampler = DiscreteSampler(settings.entity, random)
+
+    val slices = settings.slices.getOrElse(Range.Default)
+    val sliceDistribution = settings.sliceDistribution.getOrElse(DistributionShape.Uniform)
+
+    val sliceRange: IndexedSeq[Slice] = (slices match {
+      case Range.Default               => (Slice.MinValue to Slice.MaxValue).map(Slice.apply)
+      case Range.Inclusive(start, end) => (start.value to end.value).map(Slice.apply)
+      case Range.Single(value)         => Seq(value)
+      case Range.Multi(ranges) =>
+        ranges.flatMap {
+          case Range.Inclusive(start, end) => (start.value to end.value).map(Slice.apply)
+          case Range.Single(value)         => Seq(value)
+          case _                           => Seq.empty
+        }
+    }).toIndexedSeq
+
+    val sliceIndexMapper = new DeterministicIndexMapper(0, sliceRange.size - 1, sliceDistribution, random)
+
+    new EntityIdSampler(entityType, entitySampler, sliceRange, sliceIndexMapper)
+  }
+}
+
+final class EntityIdSampler(
+    entityType: String,
+    entitySampler: DiscreteSampler,
+    sliceRange: IndexedSeq[Slice],
+    sliceIndexMapper: DeterministicIndexMapper) {
+
+  def sample(): EntityId = {
+    val entity = entitySampler.sample()
+    val sliceIndex = sliceIndexMapper.map(entity)
+    val slice = sliceRange(sliceIndex)
+    EntityId.create(entityType, slice, entity)
+  }
+}
+
+final class EntityIdMap[A](mapped: RangeMap[Slice, RangeMap[Int, A]]) {
+  def apply(entityId: EntityId): A = mapped(entityId.slice)(entityId.entity)
+}
+
+object EntityIdMap {
+  def apply[A](settings: ActivitySettings, mapToValue: ActivitySettings.PerEntitySettings => A): EntityIdMap[A] = {
+    val mapped = settings.perSlice.mapValues { perSliceSettings =>
+      perSliceSettings.perEntity.mapValues { perEntitySettings =>
+        mapToValue(perEntitySettings)
+      }
+    }
+    new EntityIdMap(mapped)
+  }
+}
+
+object RandomProvider {
+
+  def apply(settings: Option[RandomSettings]): RandomProvider = {
+    new RandomProvider(algorithm(settings), seed(settings))
+  }
+
+  private def algorithm(settings: Option[RandomSettings]): String =
+    settings.flatMap(_.algorithm).getOrElse("WELL_19937_C")
+
+  private def seed(settings: Option[RandomSettings]): Seq[Long] =
+    Seq(settings.flatMap(_.seed).getOrElse(System.currentTimeMillis()))
+}
+
+final class RandomProvider(val algorithm: String, val seed: Seq[Long]) {
+  def create(): UniformRandomProvider = RandomSource.valueOf(algorithm).create(seed.toArray)
+  def expand(seed: Long*): RandomProvider = new RandomProvider(algorithm, this.seed ++ seed)
+}

--- a/src/main/scala/akka/projection/testing/simulation/Iterators.scala
+++ b/src/main/scala/akka/projection/testing/simulation/Iterators.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.collection.BufferedIterator
+import scala.collection.mutable.ArrayBuffer
+import scala.collection.mutable.PriorityQueue
+
+object IteratorExtensions {
+  implicit class RichIterator[A](iterator: Iterator[A]) {
+    def zipWithSeqNr: Iterator[(A, Int)] = {
+      iterator.zipWithIndex.map { case (element, index) => (element, index + 1) }
+    }
+  }
+}
+
+final class MergedIterator[A](iterators: Seq[Iterator[A]])(implicit ordering: Ordering[A]) extends Iterator[A] {
+
+  private val iteratorQueue =
+    PriorityQueue.empty[BufferedIterator[A]](Ordering.by[BufferedIterator[A], A](_.head)(ordering.reverse))
+
+  // initialize the queue with all non-empty iterators
+  iterators.map(_.buffered).filter(_.hasNext).foreach(iterator => iteratorQueue.enqueue(iterator))
+
+  def hasNext: Boolean = iteratorQueue.nonEmpty
+
+  def next(): A = {
+    if (!hasNext) throw new NoSuchElementException("next on empty iterator")
+
+    val minIterator = iteratorQueue.dequeue()
+    val result = minIterator.next()
+
+    // re-insert the iterator if it still has elements
+    if (minIterator.hasNext) iteratorQueue.enqueue(minIterator)
+
+    result
+  }
+}
+
+final class FlatMergedIterator[A](source: Iterator[Iterator[A]])(implicit ordering: Ordering[A]) extends Iterator[A] {
+  private val bufferedSource = source.filter(_.hasNext).map(_.buffered).buffered
+
+  private val iteratorQueue =
+    PriorityQueue.empty[BufferedIterator[A]](Ordering.by[BufferedIterator[A], A](_.head)(ordering.reverse))
+
+  private def mergeNewIterators(): Unit = {
+    while (bufferedSource.hasNext &&
+      (iteratorQueue.isEmpty || ordering.lteq(bufferedSource.head.head, iteratorQueue.head.head))) {
+      iteratorQueue.enqueue(bufferedSource.next())
+    }
+  }
+
+  def hasNext: Boolean = {
+    mergeNewIterators()
+    iteratorQueue.nonEmpty
+  }
+
+  def next(): A = {
+    if (!hasNext) throw new NoSuchElementException("next on empty iterator")
+
+    val minIterator = iteratorQueue.dequeue()
+    val result = minIterator.next()
+
+    // re-insert the iterator if it still has elements
+    if (minIterator.hasNext) {
+      iteratorQueue.enqueue(minIterator)
+    }
+
+    result
+  }
+}
+
+final class GroupedIterator[A, B](iterator: Iterator[A], boundaries: Iterator[B], point: A => B)(implicit
+    ordering: Ordering[B])
+    extends Iterator[Seq[A]] {
+
+  private val bufferedIterator = iterator.buffered
+
+  override def hasNext: Boolean = bufferedIterator.hasNext
+
+  override def next(): Seq[A] = {
+    if (!hasNext) throw new NoSuchElementException("next on empty iterator")
+
+    val group = ArrayBuffer.empty[A]
+    val boundary = if (boundaries.hasNext) Some(boundaries.next()) else None
+
+    while (bufferedIterator.hasNext && boundary.forall(ordering.lt(point(bufferedIterator.head), _))) {
+      group += bufferedIterator.next()
+    }
+
+    group.toSeq
+  }
+}

--- a/src/main/scala/akka/projection/testing/simulation/Point.scala
+++ b/src/main/scala/akka/projection/testing/simulation/Point.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.concurrent.duration._
+
+import org.apache.commons.rng.sampling.distribution.ZigguratSampler
+
+// Represents a point in time in seconds
+final class Point(val value: Double) extends AnyVal {
+  def +(that: Point): Point = new Point(this.value + that.value)
+
+  def -(that: Point): Point = new Point(this.value - that.value)
+
+  def /(that: Point): Double = this.value / that.value
+
+  def <(that: Point): Boolean = this.value < that.value
+
+  def <=(that: Point): Boolean = this.value <= that.value
+
+  def >(that: Point): Boolean = this.value > that.value
+
+  def >=(that: Point): Boolean = this.value >= that.value
+
+  def toDuration: FiniteDuration = value.seconds
+
+  override def toString: String = f"$value%.6fs"
+}
+
+object Point {
+  val Zero = Point(0)
+
+  def apply(value: Double): Point = new Point(value)
+
+  def apply(duration: FiniteDuration): Point = Point(durationToSeconds(duration))
+
+  def durationToSeconds(duration: FiniteDuration): Double = duration.toNanos / 1.second.toNanos.toDouble
+
+  implicit val ordering: Ordering[Point] = Ordering.by[Point, Double](_.value)
+}
+
+sealed trait PointProcess {
+  def min: Point
+  def max: Point
+  def points(): Iterator[Point]
+}
+
+object PointProcess {
+
+  def apply(
+      settings: PointProcessSettings,
+      start: FiniteDuration,
+      duration: FiniteDuration,
+      random: RandomProvider): PointProcess = {
+    val minPoint = Point(start)
+    val maxPoint = minPoint + Point(duration)
+    PointProcess(settings, minPoint, maxPoint, random)
+  }
+
+  def apply(settings: PointProcessSettings, minPoint: Point, maxPoint: Point, random: RandomProvider): PointProcess = {
+    settings match {
+      case PointProcessSettings.PoissonSettings(rate) =>
+        Poisson(RateFunction(rate, maxPoint, random), minPoint, maxPoint, random)
+    }
+  }
+
+  object Poisson {
+    def apply(rate: RateFunction, min: Point, max: Point, random: RandomProvider): Poisson = {
+      rate match {
+        case RateFunction.Constant(rate) => HomogeneousPoisson(rate, min, max, random)
+        case varying                     => NonHomogeneousPoisson(varying, min, max, random)
+      }
+    }
+  }
+
+  sealed trait Poisson extends PointProcess
+
+  final case class HomogeneousPoisson(rate: Rate, min: Point, max: Point, random: RandomProvider) extends Poisson {
+
+    override def points(): Iterator[Point] = {
+      val exponentialSampler = ZigguratSampler.Exponential.of(random.create(), 1 / rate.value)
+      def nextInterval() = Point(exponentialSampler.sample())
+      Iterator
+        .unfold(min) { previous =>
+          val next = previous + nextInterval()
+          if (next < max) Some((next, next)) else None
+        }
+    }
+  }
+
+  final case class NonHomogeneousPoisson(rate: RateFunction, min: Point, max: Point, random: RandomProvider)
+      extends Poisson {
+
+    override def points(): Iterator[Point] = {
+      val homogenous = HomogeneousPoisson(rate.max, min, max, random)
+      val acceptRandom = random.create()
+      // apply thinning to create non-homogenous process with varying intensity
+      def accept(point: Point): Boolean = acceptRandom.nextDouble() < (rate(point).value / rate.max.value)
+      homogenous.points().filter(accept)
+    }
+  }
+}

--- a/src/main/scala/akka/projection/testing/simulation/Rate.scala
+++ b/src/main/scala/akka/projection/testing/simulation/Rate.scala
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import java.text.DecimalFormat
+
+import scala.concurrent.duration._
+
+import org.apache.commons.rng.UniformRandomProvider
+import org.apache.commons.rng.sampling.distribution.ZigguratSampler
+
+// Represents a rate in count per second as a value class over double
+final class Rate(val value: Double) extends AnyVal {
+  def +(that: Rate): Rate = new Rate(this.value + that.value)
+
+  def -(that: Rate): Rate = new Rate(this.value - that.value)
+
+  def *(x: Double): Rate = new Rate(this.value * x)
+
+  override def toString: String = {
+    new DecimalFormat("#.######").format(value) + "/s"
+  }
+}
+
+object Rate {
+  def apply(value: Double): Rate = new Rate(value)
+
+  def max(x: Rate, y: Rate): Rate = new Rate(math.max(x.value, y.value))
+}
+
+sealed trait RateFunction {
+  def max: Rate
+  def apply(point: Point): Rate
+}
+
+object RateFunction {
+  def apply(settings: RateFunctionSettings, duration: FiniteDuration, random: RandomProvider): RateFunction = {
+    RateFunction(settings, Point(duration), random)
+  }
+
+  def apply(settings: RateFunctionSettings, maxPoint: Point, random: RandomProvider): RateFunction = {
+    settings match {
+      case RateFunctionSettings.ConstantSettings(value) =>
+        Constant(value.toRate)
+      case RateFunctionSettings.LinearSettings(initial, target) =>
+        Linear(initial.toRate, target.toRate, maxPoint)
+      case RateFunctionSettings.SinusoidalSettings(base, amplitude, period, shift) =>
+        Sinusoidal(base.toRate, amplitude.toRate, Point(period), shift.map(Point.apply))
+      case RateFunctionSettings.RandomWalkSettings(initial, min, max, volatility, trend) =>
+        RandomWalk(initial.toRate, min.toRate, max.toRate, volatility, trend.getOrElse(0.0), random.create())
+      case RateFunctionSettings.BurstSettings(base, peak, start, up, burst, down) =>
+        Burst(base.toRate, peak.toRate, Point(start), Point(up), Point(burst), Point(down))
+      case RateFunctionSettings.AdditiveSettings(rates) =>
+        Additive(rates.map(apply(_, maxPoint, random)))
+      case RateFunctionSettings.ModulatedSettings(carrier, modulator, strength) =>
+        Modulated(apply(carrier, maxPoint, random), apply(modulator, maxPoint, random), strength.getOrElse(1.0))
+      case RateFunctionSettings.CompositeSettings(rates) =>
+        Composite(rates.map(weighted => Weighted(apply(weighted.rate, maxPoint, random), weighted.weight)))
+    }
+  }
+
+  final case class Constant(value: Rate) extends RateFunction {
+
+    override def max: Rate = value
+
+    override def apply(point: Point): Rate = value
+  }
+
+  final case class Linear(initial: Rate, target: Rate, maxPoint: Point) extends RateFunction {
+
+    override def max: Rate = Rate.max(initial, target)
+
+    override def apply(point: Point): Rate = initial + (target - initial) * (point / maxPoint)
+  }
+
+  final case class Sinusoidal(base: Rate, amplitude: Rate, period: Point, shift: Option[Point]) extends RateFunction {
+
+    private val frequency = 2 * math.Pi * (1 / period.value)
+
+    private val phase = shift.fold(0.0)(shift => 2 * math.Pi * (shift.value / period.value))
+
+    override def max: Rate = base + amplitude
+
+    override def apply(point: Point): Rate = base + (amplitude * math.sin(frequency * point.value + phase))
+  }
+
+  final case class RandomWalk(
+      initial: Rate,
+      min: Rate,
+      max: Rate,
+      volatility: Double,
+      trend: Double,
+      random: UniformRandomProvider)
+      extends RateFunction {
+
+    private val sampler = ZigguratSampler.NormalizedGaussian.of(random)
+
+    private var current = initial
+    private var lastPoint: Option[Point] = None
+
+    override def apply(point: Point): Rate = {
+      lastPoint match {
+        case Some(last) =>
+          val delta = point.value - last.value
+          val change = sampler.sample() * volatility * math.sqrt(delta) + trend * delta
+          current = Rate(math.max(min.value, math.min(max.value, current.value + change)))
+        case None =>
+      }
+      lastPoint = Some(point)
+      current
+    }
+  }
+
+  final case class Burst(base: Rate, peak: Rate, start: Point, up: Point, burst: Point, down: Point)
+      extends RateFunction {
+
+    override def max: Rate = peak
+
+    override def apply(point: Point): Rate = {
+      val peakStart = start + up
+      val peakEnd = peakStart + burst
+      val burstEnd = peakEnd + down
+
+      if (point < start) { // before burst
+        base
+      } else if (point < peakStart) { // linear ramp up to peak
+        val progress = (point - start) / up
+        base + (peak - base) * progress
+      } else if (point < peakEnd) { // burst peak
+        peak
+      } else if (point < burstEnd) { // linear ramp down from peak
+        val progress = (point - peakEnd) / down
+        peak - (peak - base) * progress
+      } else { // after burst
+        base
+      }
+    }
+  }
+
+  final case class Additive(functions: Seq[RateFunction]) extends RateFunction {
+    override def max: Rate = Rate(functions.map(_.max.value).sum)
+
+    override def apply(point: Point): Rate = Rate(functions.map(function => function(point).value).sum)
+  }
+
+  final case class Modulated(carrier: RateFunction, modulator: RateFunction, strength: Double) extends RateFunction {
+    override def max: Rate = carrier.max * (1.0 + strength)
+
+    override def apply(point: Point): Rate = {
+      val baseRate = carrier(point)
+      val modulatorFactor = 1.0 + (modulator(point).value / modulator.max.value) * strength
+      baseRate * math.max(0.0, modulatorFactor)
+    }
+  }
+
+  final case class Weighted(function: RateFunction, weight: Double)
+
+  final case class Composite(weighted: Seq[Weighted]) extends RateFunction {
+    private val totalWeight = weighted.map(_.weight).sum
+
+    override def max: Rate = {
+      Rate(weighted.map(rate => rate.function.max.value * (rate.weight / totalWeight)).sum)
+    }
+
+    override def apply(point: Point): Rate = {
+      Rate(weighted.map(rate => rate.function(point).value * (rate.weight / totalWeight)).sum)
+    }
+  }
+}

--- a/src/main/scala/akka/projection/testing/simulation/Sampler.scala
+++ b/src/main/scala/akka/projection/testing/simulation/Sampler.scala
@@ -1,0 +1,885 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.concurrent.duration.FiniteDuration
+import scala.util.hashing.MurmurHash3
+
+import akka.projection.testing.simulation.Sampled.Continuous
+import akka.projection.testing.simulation.Sampled.Discrete
+import org.apache.commons.rng.UniformRandomProvider
+import org.apache.commons.rng.sampling.ArraySampler
+import org.apache.commons.statistics.distribution.ContinuousDistribution
+import org.apache.commons.statistics.distribution.ExponentialDistribution
+import org.apache.commons.statistics.distribution.GammaDistribution
+import org.apache.commons.statistics.distribution.LogNormalDistribution
+import org.apache.commons.statistics.distribution.ParetoDistribution
+import org.apache.commons.statistics.distribution.UniformContinuousDistribution
+import org.apache.commons.statistics.distribution.UniformDiscreteDistribution
+import org.apache.commons.statistics.distribution.WeibullDistribution
+import org.apache.commons.statistics.distribution.ZipfDistribution
+
+sealed trait Sampled[A] {
+  def isDiscrete: Boolean
+}
+
+object Sampled {
+  final case class Discrete[A](value: DiscreteValue[A]) extends Sampled[A] {
+    override def isDiscrete: Boolean = true
+  }
+
+  final case class Continuous[A](value: ContinuousValue[A]) extends Sampled[A] {
+    override def isDiscrete: Boolean = false
+  }
+
+  implicit val SampledInt: Sampled[Int] = Discrete(DiscreteValue.IntValue)
+  implicit val SampledSlice: Sampled[Slice] = Discrete(DiscreteValue.SliceValue)
+  implicit val SampledCount: Sampled[Count] = Discrete(DiscreteValue.CountValue)
+  implicit val SampledDataSize: Sampled[DataSize] = Discrete(DiscreteValue.DataSizeValue)
+  implicit val SampledDuration: Sampled[FiniteDuration] = Continuous(ContinuousValue.DurationValue)
+}
+
+sealed trait Sampler[A] {
+  def min: A
+  def max: A
+  def sample(): A
+}
+
+object Sampler {
+
+  def apply[A](settings: SamplerSettings[A], random: RandomProvider)(implicit sampled: Sampled[A]): Sampler[A] = {
+    sampled match {
+      case Discrete(value)   => new FromDiscrete(DiscreteSampler(settings, random)(value), value)
+      case Continuous(value) => new FromContinuous(ContinuousSampler(settings, random)(value), value)
+    }
+  }
+
+  final class FromDiscrete[A](sampler: DiscreteSampler, value: DiscreteValue[A]) extends Sampler[A] {
+    override def min: A = value.fromInt(sampler.min)
+    override def max: A = value.fromInt(sampler.max)
+    override def sample(): A = value.fromInt(sampler.sample())
+  }
+
+  final class FromContinuous[A](sampler: ContinuousSampler, value: ContinuousValue[A]) extends Sampler[A] {
+    override def min: A = value.fromDouble(sampler.min)
+    override def max: A = value.fromDouble(sampler.max)
+    override def sample(): A = value.fromDouble(sampler.sample())
+  }
+}
+
+sealed trait DiscreteValue[A] {
+  def toInt(value: A): Int
+  def fromInt(value: Int): A
+}
+
+object DiscreteValue {
+  implicit object IntValue extends DiscreteValue[Int] {
+    override def toInt(value: Int): Int = value
+    override def fromInt(value: Int): Int = value
+  }
+
+  implicit object SliceValue extends DiscreteValue[Slice] {
+    override def toInt(slice: Slice): Int = slice.value
+    override def fromInt(value: Int): Slice = Slice(value)
+  }
+
+  implicit object CountValue extends DiscreteValue[Count] {
+    override def toInt(count: Count): Int = count.toInt
+    override def fromInt(value: Int): Count = Count(value)
+  }
+
+  implicit object DataSizeValue extends DiscreteValue[DataSize] {
+    override def toInt(dataSize: DataSize): Int = dataSize.toBytes
+    override def fromInt(bytes: Int): DataSize = DataSize(bytes)
+  }
+}
+
+sealed trait DiscreteSampler {
+  def min: Int
+  def max: Int
+  def sample(): Int
+}
+
+object DiscreteSampler {
+
+  def apply[Value](settings: SamplerSettings[Value], random: RandomProvider)(implicit
+      discreteValue: DiscreteValue[Value]): DiscreteSampler = {
+    val sampler = settings match {
+      case SamplerSettings.ConstantSettings(value) =>
+        Constant(discreteValue.toInt(value))
+
+      case SamplerSettings.UniformSettings(minValue, maxValue) =>
+        Uniform(discreteValue.toInt(minValue), discreteValue.toInt(maxValue), random.create())
+
+      case SamplerSettings.IncrementalSettings(startValue, stepValue, limitValue) =>
+        Incremental(
+          discreteValue.toInt(startValue),
+          discreteValue.toInt(stepValue),
+          limitValue.map(discreteValue.toInt))
+
+      case SamplerSettings.ZipfSettings(minValue, maxValue, exponent, _) =>
+        val min = discreteValue.toInt(minValue)
+        val max = discreteValue.toInt(maxValue)
+        Zipf(min, max, exponent, random.create())
+
+      case SamplerSettings.ExponentialSettings(meanValue, minValue, maxValue, _) =>
+        val mean = discreteValue.toInt(meanValue).toDouble
+        val min = minValue.map(discreteValue.toInt).getOrElse(0)
+        val max = maxValue.map(discreteValue.toInt).getOrElse(Int.MaxValue)
+        val continuousSampler =
+          ContinuousSampler.Exponential(mean, min.toDouble, max.toDouble, random.create())
+        Discretized(continuousSampler, min, max)
+
+      case SamplerSettings.WeibullSettings(shape, scaleValue, minValue, maxValue, _) =>
+        val scale = discreteValue.toInt(scaleValue).toDouble
+        val min = minValue.map(discreteValue.toInt).getOrElse(0)
+        val max = maxValue.map(discreteValue.toInt).getOrElse(Int.MaxValue)
+        val continuousSampler =
+          ContinuousSampler.Weibull(shape, scale, min.toDouble, max.toDouble, random.create())
+        Discretized(continuousSampler, min, max)
+
+      case SamplerSettings.GammaSettings(shape, scaleValue, minValue, maxValue, _) =>
+        val scale = discreteValue.toInt(scaleValue).toDouble
+        val min = minValue.map(discreteValue.toInt).getOrElse(0)
+        val max = maxValue.map(discreteValue.toInt).getOrElse(Int.MaxValue)
+        val continuousSampler =
+          ContinuousSampler.Gamma(shape, scale, min.toDouble, max.toDouble, random.create())
+        Discretized(continuousSampler, min, max)
+
+      case logNormal: SamplerSettings.LogNormalSettings[Value] =>
+        val min = logNormal.min.map(discreteValue.toInt).getOrElse(0)
+        val max = logNormal.max.map(discreteValue.toInt).getOrElse(Int.MaxValue)
+
+        val continuousSampler = logNormal match {
+          case SamplerSettings.LogNormalSettings.MuSigmaSettings(mu, sigma, _, _, _) =>
+            ContinuousSampler.LogNormal(mu, sigma, min.toDouble, max.toDouble, random.create())
+
+          case SamplerSettings.LogNormalSettings.ScaleShapeSettings(scaleValue, shape, _, _, _) =>
+            val scale = discreteValue.toInt(scaleValue).toDouble
+            ContinuousSampler.LogNormal.fromScaleShape(scale, shape, min.toDouble, max.toDouble, random.create())
+
+          case SamplerSettings.LogNormalSettings.MeanStdDevSettings(meanValue, stdDevValue, _, _, _) =>
+            val mean = discreteValue.toInt(meanValue).toDouble
+            val stdDev = discreteValue.toInt(stdDevValue).toDouble
+            ContinuousSampler.LogNormal.fromMeanStdDev(mean, stdDev, min.toDouble, max.toDouble, random.create())
+
+          case SamplerSettings.LogNormalSettings.MedianP95Settings(medianValue, p95Value, _, _, _) =>
+            val median = discreteValue.toInt(medianValue).toDouble
+            val p95 = discreteValue.toInt(p95Value).toDouble
+            ContinuousSampler.LogNormal.fromMedianAndP95(median, p95, min.toDouble, max.toDouble, random.create())
+        }
+
+        Discretized(continuousSampler, min, max)
+
+      case pareto: SamplerSettings.ParetoSettings[Value] =>
+        val min = pareto match {
+          case SamplerSettings.ParetoSettings.ScaleShapeSettings(scale, _, _, _) => discreteValue.toInt(scale)
+          case SamplerSettings.ParetoSettings.MinP95Settings(min, _, _, _)       => discreteValue.toInt(min)
+        }
+        val max = pareto.max.map(discreteValue.toInt).getOrElse(Int.MaxValue)
+
+        val continuousSampler = pareto match {
+          case SamplerSettings.ParetoSettings.ScaleShapeSettings(scaleValue, shape, _, _) =>
+            val scale = discreteValue.toInt(scaleValue).toDouble
+            ContinuousSampler.Pareto(scale, shape, max.toDouble, random.create())
+
+          case SamplerSettings.ParetoSettings.MinP95Settings(minValue, p95Value, _, _) =>
+            val min = discreteValue.toInt(minValue).toDouble
+            val p95 = discreteValue.toInt(p95Value).toDouble
+            ContinuousSampler.Pareto.fromMinAndP95(min, p95, max.toDouble, random.create())
+        }
+
+        Discretized(continuousSampler, min, max)
+
+      case SamplerSettings.CategoricalSettings(categories) =>
+        val intCategories = categories.map(category => Category(discreteValue.toInt(category.value), category.weight))
+        Categorical(intCategories, random.create())
+
+      case SamplerSettings.CompositeSettings(samplers) =>
+        val weightedSamplers =
+          samplers.map(weighted => WeightedSampler(DiscreteSampler(weighted.sampler, random), weighted.weight))
+        Composite(weightedSamplers, random.create())
+    }
+
+    if (settings.shuffled.getOrElse(false)) ShuffledSampler(sampler, random) else sampler
+  }
+
+  final case class Constant(value: Int) extends DiscreteSampler {
+    override def min: Int = value
+    override def max: Int = value
+    override def sample(): Int = value
+  }
+
+  final case class Uniform(min: Int, max: Int, random: UniformRandomProvider) extends DiscreteSampler {
+
+    private val distribution = UniformDiscreteDistribution.of(min, max)
+    private val sampler = distribution.createSampler(random)
+
+    override def sample(): Int = sampler.sample()
+  }
+
+  final case class Incremental(start: Int, step: Int, limit: Option[Int]) extends DiscreteSampler {
+    private var counter = start
+
+    override def min: Int = start
+    override def max: Int = limit.getOrElse(Int.MaxValue)
+
+    override def sample(): Int = {
+      val value = counter
+      counter += step
+      if (limit.exists(counter.>=)) counter = start
+      value
+    }
+  }
+
+  final case class Zipf(min: Int, max: Int, exponent: Double, random: UniformRandomProvider) extends DiscreteSampler {
+
+    private val numberOfElements = max - min + 1
+
+    private val distribution = ZipfDistribution.of(numberOfElements, exponent)
+    private val sampler = distribution.createSampler(random)
+
+    override def sample(): Int = min + sampler.sample() - 1
+  }
+
+  // Converts any continuous sampler into a discrete sampler by rounding.
+  final case class Discretized(sampler: ContinuousSampler, min: Int, max: Int) extends DiscreteSampler {
+    override def sample(): Int = {
+      val value = math.round(sampler.sample()).toInt
+      math.min(math.max(value, min), max) // recheck bounds
+    }
+  }
+
+  final case class Category(value: Int, weight: Double)
+
+  object Category {
+    implicit val weightedItem: WeightedItem[Category] = new WeightedItem[Category] {
+      def weight(category: Category): Double = category.weight
+    }
+  }
+
+  final case class Categorical(categories: Seq[Category], random: UniformRandomProvider) extends DiscreteSampler {
+    private val weightedChoice = new WeightedChoice(categories, random)
+
+    override val min: Int = categories.map(_.value).min
+    override val max: Int = categories.map(_.value).max
+
+    override def sample(): Int = weightedChoice.choose().value
+  }
+
+  final case class WeightedSampler(sampler: DiscreteSampler, weight: Double)
+
+  object WeightedSampler {
+    implicit val weightedItem: WeightedItem[WeightedSampler] = new WeightedItem[WeightedSampler] {
+      def weight(sampler: WeightedSampler): Double = sampler.weight
+    }
+  }
+
+  final case class Composite(weightedSamplers: Seq[WeightedSampler], random: UniformRandomProvider)
+      extends DiscreteSampler {
+    private val weightedChoice = new WeightedChoice(weightedSamplers, random)
+
+    override val min: Int = weightedSamplers.map(_.sampler.min).min
+    override val max: Int = weightedSamplers.map(_.sampler.max).max
+
+    override def sample(): Int = weightedChoice.choose().sampler.sample()
+  }
+
+  object ShuffledSampler {
+    val MaxShuffledElements = 5_000 // use fully shuffled array up to this size
+    val MaxStretchedElements = 1_000_000 // use stretched sampling up to this size
+    val StretchFactor = 100 // stretch factor for medium-range distributions
+
+    def apply(underlying: DiscreteSampler, random: RandomProvider): DiscreteSampler = {
+      val range = underlying.max.toLong - underlying.min.toLong + 1
+      if (range <= MaxShuffledElements) {
+        // small range: use full shuffling to maintain statistical properties
+        FullyShuffled(underlying, random.create())
+      } else if (range <= MaxStretchedElements) {
+        // medium range: use stretched scrambling for good statistical approximation
+        StretchedScrambled(underlying, random.create(), StretchFactor)
+      } else {
+        // large range: use direct scrambling
+        DirectScrambled(underlying, random.create())
+      }
+    }
+
+    // for small ranges: fully shuffle all possible values
+    final case class FullyShuffled(underlying: DiscreteSampler, random: UniformRandomProvider) extends DiscreteSampler {
+
+      override def min: Int = underlying.min
+      override def max: Int = underlying.max
+
+      private val shuffled: Array[Int] = {
+        ArraySampler.shuffle(random, (min to max).toArray)
+      }
+
+      override def sample(): Int = shuffled(underlying.sample() - min)
+    }
+
+    // for medium ranges: stretch the distribution before scrambling
+    final case class StretchedScrambled(underlying: DiscreteSampler, random: UniformRandomProvider, stretchFactor: Int)
+        extends DiscreteSampler {
+
+      override def min: Int = underlying.min
+      override def max: Int = underlying.max
+
+      private val numberOfElements = max - min + 1
+
+      private val seed = random.nextInt()
+
+      override def sample(): Int = {
+        val sampled = underlying.sample()
+        // stretched value with random offset
+        val stretched = (sampled - min) * stretchFactor + random.nextInt(stretchFactor)
+        min + math.abs(hash(stretched)) % numberOfElements
+      }
+
+      private def hash(value: Int): Int = {
+        MurmurHash3.mixLast(MurmurHash3.mixLast(0x9747b28c, value), seed)
+      }
+    }
+
+    // for large ranges: direct scrambling
+    final case class DirectScrambled(underlying: DiscreteSampler, random: UniformRandomProvider)
+        extends DiscreteSampler {
+
+      override def min: Int = underlying.min
+      override def max: Int = underlying.max
+
+      private val numberOfElements = max.toLong - min.toLong + 1
+
+      private val seed = random.nextInt()
+
+      override def sample(): Int = scramble(underlying.sample())
+
+      private def scramble(value: Int): Int = {
+        if (numberOfElements > Int.MaxValue) {
+          min + (hash64(value) % numberOfElements).toInt
+        } else {
+          min + math.abs(hash(value)) % numberOfElements.toInt
+        }
+      }
+
+      private def hash(value: Int): Int = {
+        MurmurHash3.mixLast(MurmurHash3.mixLast(0x9747b28c, value), seed)
+      }
+
+      private def hash64(value: Int): Long = {
+        val h1 = MurmurHash3.mixLast(0x9747b28c, value)
+        val h2 = MurmurHash3.mixLast(seed, value)
+        math.abs((h1.toLong << 32) | (h2.toLong & 0xffffffffL))
+      }
+    }
+  }
+
+}
+
+sealed trait ContinuousValue[A] {
+  def toDouble(value: A): Double
+  def fromDouble(value: Double): A
+}
+
+object ContinuousValue {
+  implicit object DurationValue extends ContinuousValue[FiniteDuration] {
+    override def toDouble(duration: FiniteDuration): Double = Point(duration).value
+    override def fromDouble(value: Double): FiniteDuration = Point(value).toDuration
+  }
+}
+
+sealed trait ContinuousSampler {
+  def min: Double
+  def max: Double
+  def sample(): Double
+}
+
+object ContinuousSampler {
+
+  def apply[A](settings: SamplerSettings[A], random: RandomProvider)(implicit
+      continuousValue: ContinuousValue[A]): ContinuousSampler = {
+    settings match {
+      case SamplerSettings.ConstantSettings(value) =>
+        Constant(continuousValue.toDouble(value))
+
+      case SamplerSettings.UniformSettings(minValue, maxValue) =>
+        val min = continuousValue.toDouble(minValue)
+        val max = continuousValue.toDouble(maxValue)
+        Uniform(min, max, random.create())
+
+      case SamplerSettings.IncrementalSettings(startValue, stepValue, limitValue) =>
+        Incremental(
+          continuousValue.toDouble(startValue),
+          continuousValue.toDouble(stepValue),
+          limitValue.map(continuousValue.toDouble))
+
+      case SamplerSettings.ZipfSettings(_, _, _, _) =>
+        throw new IllegalArgumentException("Zipf distribution is not supported for continuous samplers")
+
+      case SamplerSettings.ExponentialSettings(meanValue, minValue, maxValue, _) =>
+        val mean = continuousValue.toDouble(meanValue)
+        val min = minValue.map(continuousValue.toDouble).getOrElse(0.0)
+        val max = maxValue.map(continuousValue.toDouble).getOrElse(Double.PositiveInfinity)
+        Exponential(mean, min, max, random.create())
+
+      case SamplerSettings.WeibullSettings(shape, scaleValue, minValue, maxValue, _) =>
+        val scale = continuousValue.toDouble(scaleValue)
+        val min = minValue.map(continuousValue.toDouble).getOrElse(0.0)
+        val max = maxValue.map(continuousValue.toDouble).getOrElse(Double.PositiveInfinity)
+        Weibull(shape, scale, min, max, random.create())
+
+      case SamplerSettings.GammaSettings(shape, scaleValue, minValue, maxValue, _) =>
+        val scale = continuousValue.toDouble(scaleValue)
+        val min = minValue.map(continuousValue.toDouble).getOrElse(0.0)
+        val max = maxValue.map(continuousValue.toDouble).getOrElse(Double.PositiveInfinity)
+        Gamma(shape, scale, min, max, random.create())
+
+      case logNormal: SamplerSettings.LogNormalSettings[A] =>
+        val min = logNormal.min.map(continuousValue.toDouble).getOrElse(0.0)
+        val max = logNormal.max.map(continuousValue.toDouble).getOrElse(Double.PositiveInfinity)
+
+        logNormal match {
+          case SamplerSettings.LogNormalSettings.MuSigmaSettings(mu, sigma, _, _, _) =>
+            LogNormal(mu, sigma, min, max, random.create())
+
+          case SamplerSettings.LogNormalSettings.ScaleShapeSettings(scaleValue, shape, _, _, _) =>
+            val scale = continuousValue.toDouble(scaleValue)
+            LogNormal.fromScaleShape(scale, shape, min, max, random.create())
+
+          case SamplerSettings.LogNormalSettings.MeanStdDevSettings(meanValue, stdDevValue, _, _, _) =>
+            val mean = continuousValue.toDouble(meanValue)
+            val stdDev = continuousValue.toDouble(stdDevValue)
+            LogNormal.fromMeanStdDev(mean, stdDev, min, max, random.create())
+
+          case SamplerSettings.LogNormalSettings.MedianP95Settings(medianValue, p95Value, _, _, _) =>
+            val median = continuousValue.toDouble(medianValue)
+            val p95 = continuousValue.toDouble(p95Value)
+            LogNormal.fromMedianAndP95(median, p95, min, max, random.create())
+        }
+
+      case pareto: SamplerSettings.ParetoSettings[A] =>
+        val max = pareto.max.map(continuousValue.toDouble).getOrElse(Double.PositiveInfinity)
+
+        pareto match {
+          case SamplerSettings.ParetoSettings.ScaleShapeSettings(scaleValue, shape, _, _) =>
+            val scale = continuousValue.toDouble(scaleValue)
+            Pareto(scale, shape, max, random.create())
+
+          case SamplerSettings.ParetoSettings.MinP95Settings(minValue, p95Value, _, _) =>
+            val min = continuousValue.toDouble(minValue)
+            val p95 = continuousValue.toDouble(p95Value)
+            Pareto.fromMinAndP95(min, p95, max, random.create())
+        }
+
+      case SamplerSettings.CategoricalSettings(categories) =>
+        val doubleCategories = categories.map { category =>
+          Category(continuousValue.toDouble(category.value), category.weight)
+        }
+        Categorical(doubleCategories, random.create())
+
+      case SamplerSettings.CompositeSettings(samplers) =>
+        val weightedSamplers = samplers.map { weighted =>
+          WeightedSampler(ContinuousSampler(weighted.sampler, random), weighted.weight)
+        }
+        Composite(weightedSamplers, random.create())
+    }
+  }
+
+  abstract class BoundedContinuousSampler(min: Double, max: Double) extends ContinuousSampler {
+
+    protected def sampleUnbounded(): Double
+
+    override final def sample(): Double = {
+      val value = sampleUnbounded()
+      math.min(math.max(value, min), max)
+    }
+  }
+
+  final case class Constant(value: Double) extends ContinuousSampler {
+    override def min: Double = value
+    override def max: Double = value
+    override def sample(): Double = value
+  }
+
+  // https://en.wikipedia.org/wiki/Continuous_uniform_distribution
+  final case class Uniform(min: Double, max: Double, random: UniformRandomProvider) extends ContinuousSampler {
+
+    private val distribution = UniformContinuousDistribution.of(min, max)
+    private val sampler = distribution.createSampler(random)
+
+    override def sample(): Double = sampler.sample()
+  }
+
+  final case class Incremental(start: Double, step: Double, limit: Option[Double]) extends ContinuousSampler {
+    private var counter = start
+
+    override def min: Double = start
+    override def max: Double = limit.getOrElse(Double.PositiveInfinity)
+
+    override def sample(): Double = {
+      val value = counter
+      counter += step
+      if (limit.exists(counter.>=)) counter = start
+      value
+    }
+  }
+
+  // https://en.wikipedia.org/wiki/Exponential_distribution
+  final case class Exponential(mean: Double, min: Double, max: Double, random: UniformRandomProvider)
+      extends BoundedContinuousSampler(min, max) {
+
+    private val distribution = ExponentialDistribution.of(mean)
+    private val sampler = distribution.createSampler(random)
+
+    override protected def sampleUnbounded(): Double = sampler.sample()
+  }
+
+  // https://en.wikipedia.org/wiki/Weibull_distribution
+  final case class Weibull(shape: Double, scale: Double, min: Double, max: Double, random: UniformRandomProvider)
+      extends BoundedContinuousSampler(min, max) {
+
+    private val distribution = WeibullDistribution.of(shape, scale)
+    private val sampler = distribution.createSampler(random)
+
+    override protected def sampleUnbounded(): Double = sampler.sample()
+  }
+
+  // https://en.wikipedia.org/wiki/Gamma_distribution
+  final case class Gamma(shape: Double, scale: Double, min: Double, max: Double, random: UniformRandomProvider)
+      extends BoundedContinuousSampler(min, max) {
+
+    private val distribution = GammaDistribution.of(shape, scale)
+    private val sampler = distribution.createSampler(random)
+
+    override protected def sampleUnbounded(): Double = sampler.sample()
+  }
+
+  // https://en.wikipedia.org/wiki/Log-normal_distribution
+  final case class LogNormal(mu: Double, sigma: Double, min: Double, max: Double, random: UniformRandomProvider)
+      extends BoundedContinuousSampler(min, max) {
+
+    private val distribution = LogNormalDistribution.of(mu, sigma)
+    private val sampler = distribution.createSampler(random)
+
+    override protected def sampleUnbounded(): Double = sampler.sample()
+  }
+
+  object LogNormal {
+    def fromScaleShape(
+        scale: Double,
+        shape: Double,
+        min: Double,
+        max: Double,
+        random: UniformRandomProvider): LogNormal = {
+      val (mu, sigma) = DistributionParameters.LogNormal.muSigmaFromScaleShape(scale, shape)
+      LogNormal(mu, sigma, min, max, random)
+    }
+
+    def fromMeanStdDev(
+        mean: Double,
+        stdDev: Double,
+        min: Double,
+        max: Double,
+        random: UniformRandomProvider): LogNormal = {
+      val (mu, sigma) = DistributionParameters.LogNormal.muSigmaFromMeanStdDev(mean, stdDev)
+      LogNormal(mu, sigma, min, max, random)
+    }
+
+    def fromMedianAndP95(
+        median: Double,
+        p95: Double,
+        min: Double,
+        max: Double,
+        random: UniformRandomProvider): LogNormal = {
+      val (mu, sigma) = DistributionParameters.LogNormal.muSigmaFromMedianP95(median, p95)
+      LogNormal(mu, sigma, min, max, random)
+    }
+
+    def fromMinMax(min: Double, max: Double, shape: Option[Double], random: UniformRandomProvider): LogNormal = {
+      val (mu, sigma) = DistributionParameters.LogNormal.muSigmaFromMinMax(min, max, shape)
+      LogNormal(mu, sigma, min, max, random)
+    }
+  }
+
+  // https://en.wikipedia.org/wiki/Pareto_distribution
+  final case class Pareto(scale: Double, shape: Double, max: Double, random: UniformRandomProvider)
+      extends ContinuousSampler {
+
+    private val distribution = ParetoDistribution.of(scale, shape)
+    private val sampler = distribution.createSampler(random)
+
+    override def min: Double = scale // scale parameter is the minimum value in Pareto
+
+    override def sample(): Double = {
+      val value = sampler.sample()
+      math.min(value, max) // upper bound only - lower bound is already enforced by Pareto distribution
+    }
+  }
+
+  object Pareto {
+    def fromMinAndP95(min: Double, p95: Double, max: Double, random: UniformRandomProvider): Pareto = {
+      val shape = math.log(0.05) / -math.log(p95 / min)
+      Pareto(min, shape, max, random)
+    }
+  }
+
+  final case class Category(value: Double, weight: Double)
+
+  object Category {
+    implicit val weightedItem: WeightedItem[Category] = new WeightedItem[Category] {
+      def weight(category: Category): Double = category.weight
+    }
+  }
+
+  final case class Categorical(categories: Seq[Category], random: UniformRandomProvider) extends ContinuousSampler {
+    private val weightedChoice = new WeightedChoice(categories, random)
+
+    override val min: Double = categories.map(_.value).min
+    override val max: Double = categories.map(_.value).max
+
+    override def sample(): Double = weightedChoice.choose().value
+  }
+
+  final case class WeightedSampler(sampler: ContinuousSampler, weight: Double)
+
+  object WeightedSampler {
+    implicit val weightedItem: WeightedItem[WeightedSampler] = new WeightedItem[WeightedSampler] {
+      def weight(sampler: WeightedSampler): Double = sampler.weight
+    }
+  }
+
+  final case class Composite(weightedSamplers: Seq[WeightedSampler], random: UniformRandomProvider)
+      extends ContinuousSampler {
+    private val weightedChoice = new WeightedChoice(weightedSamplers, random)
+
+    override val min: Double = weightedSamplers.map(_.sampler.min).min
+    override val max: Double = weightedSamplers.map(_.sampler.max).max
+
+    override def sample(): Double = weightedChoice.choose().sampler.sample()
+  }
+}
+
+trait WeightedItem[A] {
+  def weight(item: A): Double
+}
+
+private final class WeightedChoice[A: WeightedItem](items: Seq[A], random: UniformRandomProvider) {
+  private val weighted = implicitly[WeightedItem[A]]
+  private val indexedItems = items.toIndexedSeq
+  private val weights = items.map(weighted.weight)
+  private val totalWeight = weights.sum
+  private val cumulativeWeights = weights.scanLeft(0.0)(_ + _).tail
+
+  def choose(): A = {
+    val r = random.nextDouble() * totalWeight
+    val index = cumulativeWeights.indexWhere(_ >= r)
+    indexedItems(index)
+  }
+}
+
+object DistributionParameters {
+  private val Z95 = 1.645 // 95th percentile z-score
+  private val Z99 = 2.326 // 99th percentile z-score
+
+  def exponentialMean(min: Double, max: Double): Double = {
+    // use percentile-based approach - 95% of values between min and max
+    -(max - min) / math.log(0.05)
+  }
+
+  def weibullScale(min: Double, max: Double, shape: Double): Double = {
+    (max - min) / scaleFactor(shape)
+  }
+
+  def gammaScale(min: Double, max: Double, shape: Double): Double = {
+    (max - min) / (shape * scaleFactor(shape))
+  }
+
+  private def scaleFactor(shape: Double): Double = {
+    val maxDivisor = 3.0
+    val minDivisor = 1.5
+
+    if (shape <= 0.5) {
+      maxDivisor // max divisor for very small shapes
+    } else if (shape >= 4.0) {
+      minDivisor // min divisor for normal-like shapes
+    } else {
+      // smooth transition function between scale factor values
+      val normalizedShape = (shape - 0.5) / 3.5
+      val transition = math.tanh(2.5 * normalizedShape - 1.25) / 2 + 0.5
+      maxDivisor - ((maxDivisor - minDivisor) * transition)
+    }
+  }
+
+  object LogNormal {
+
+    def muSigmaFromScaleShape(scale: Double, shape: Double): (Double, Double) = {
+      val mu = math.log(scale)
+      (mu, shape)
+    }
+
+    def muSigmaFromMeanStdDev(mean: Double, stdDev: Double): (Double, Double) = {
+      val sigma = math.sqrt(math.log(1 + (stdDev * stdDev) / (mean * mean)))
+      val mu = math.log(mean) - (sigma * sigma / 2)
+      (mu, sigma)
+    }
+
+    def muSigmaFromMedianP95(median: Double, p95: Double): (Double, Double) = {
+      val sigma = math.log(p95 / median) / Z95
+      val mu = math.log(median) // for median, z-score = 0
+      (mu, sigma)
+    }
+
+    def muSigmaFromMinMax(min: Double, max: Double, shape: Option[Double] = None): (Double, Double) = {
+      // ensure min is positive for log-normal distribution
+      val adjustedMin = if (min <= 0) math.max(0.001, max / 10000.0) else min
+      val median = math.sqrt(adjustedMin * max) // geometric mean for median
+      val mu = math.log(median)
+      val sigma = shape.getOrElse {
+        val logRatio = math.log(max / adjustedMin)
+        val percentileFactor = if (logRatio > 6.0) Z99 else Z95
+        logRatio / (2 * percentileFactor)
+      }
+      (mu, sigma)
+    }
+  }
+}
+
+object DeterministicIndexMapper {
+  // Reuse the same thresholds as ShuffledSampler for consistency
+  val MaxShuffledElements = 5_000 // use fully shuffled array up to this size
+  val MaxStretchedElements = 1_000_000 // use stretched sampling up to this size
+  val StretchFactor = 100 // stretch factor for medium-range distributions
+
+  private def hashInputToUniform(input: Int, seed: Seq[Long]): Double = {
+    var h = 0x9747b28c
+    seed.foreach { s => h = MurmurHash3.mixLast(h, s.toInt) }
+    h = MurmurHash3.mixLast(h, input)
+    val finalHash = MurmurHash3.finalizeHash(h, 4) // length=4 for Int
+    (finalHash.toDouble - Int.MinValue.toDouble) / (1L << 32)
+  }
+
+  private def scrambleIndex(index: Int, numIndices: Int, input: Int, seed: Seq[Long]): Int = {
+    if (numIndices <= 0) return 0
+    var h = 0x85ebca6b
+    seed.foreach { s => h = MurmurHash3.mixLast(h, s.toInt) }
+    h = MurmurHash3.mixLast(h, input)
+    val scrambleSeed = MurmurHash3.finalizeHash(h, 4) // length=4 for Int
+    val scrambledHash = MurmurHash3.mixLast(MurmurHash3.mixLast(0x9747b28c, index), scrambleSeed)
+    val finalScrambledHash = MurmurHash3.finalizeHash(scrambledHash, 4) // length=4 for Int
+    math.floorMod(finalScrambledHash, numIndices)
+  }
+
+  private def stretchedScrambleIndex(index: Int, numIndices: Int, input: Int, seed: Seq[Long]): Int = {
+    if (numIndices <= 0) return 0
+    var h = 0x9747b28c
+    seed.foreach { s => h = MurmurHash3.mixLast(h, s.toInt) }
+    h = MurmurHash3.mixLast(h, input)
+    val scrambleSeed = MurmurHash3.finalizeHash(h, 4) // length=4 for Int
+
+    // Apply stretch factor with deterministic offset based on input
+    val stretchedIndex = index * StretchFactor + (math.abs(scrambleSeed) % StretchFactor)
+    val finalHash = MurmurHash3.mixLast(MurmurHash3.mixLast(0x9747b28c, stretchedIndex), scrambleSeed)
+    math.abs(finalHash) % numIndices
+  }
+}
+
+final class DeterministicIndexMapper(
+    minIndex: Int,
+    maxIndex: Int,
+    distribution: DistributionShape,
+    random: RandomProvider) {
+
+  import DeterministicIndexMapper._
+
+  private val numIndices = maxIndex - minIndex + 1
+  private val baseSeed = random.seed
+
+  // For small distributions that need shuffling, pre-compute a shuffled array
+  private val shuffledIndices: Option[Array[Int]] = {
+    if (distribution.shuffled.getOrElse(false) && numIndices > 0 && numIndices <= MaxShuffledElements) {
+      val indices = (0 until numIndices).toArray
+      val rng = random.create()
+      Some(ArraySampler.shuffle(rng, indices))
+    } else {
+      None
+    }
+  }
+
+  private val underlyingDistribution = distribution match {
+    case _ if numIndices <= 0      => None
+    case DistributionShape.Uniform => None
+    case DistributionShape.Zipf(exponent, _) =>
+      Some(ZipfDistribution.of(numIndices, exponent))
+    case DistributionShape.Exponential(_) =>
+      val mean = DistributionParameters.exponentialMean(0, numIndices - 1)
+      Some(ExponentialDistribution.of(mean))
+    case DistributionShape.Weibull(shape, _) =>
+      val scaleFactor = DistributionParameters.weibullScale(0, numIndices - 1, shape)
+      val scale = if (scaleFactor == 0) Double.MaxValue else (numIndices - 1) / scaleFactor
+      Some(WeibullDistribution.of(shape, math.max(scale, 1e-9)))
+    case DistributionShape.Gamma(shape, _) =>
+      val scaleFactor = DistributionParameters.gammaScale(0, numIndices - 1, shape)
+      val scale = if (shape == 0 || scaleFactor == 0) Double.MaxValue else (numIndices - 1) / (shape * scaleFactor)
+      Some(GammaDistribution.of(shape, math.max(scale, 1e-9)))
+    case DistributionShape.LogNormal(shape, _) =>
+      val (mu, sigma) = DistributionParameters.LogNormal.muSigmaFromMinMax(0, numIndices - 1, Some(shape))
+      Some(LogNormalDistribution.of(mu, sigma))
+    case DistributionShape.Pareto(shape, _) =>
+      val scale = 1.0 // use 1.0 as minimum scale (Pareto requires scale > 0)
+      val adjustedShape = math.max(1.05, shape)
+      Some(ParetoDistribution.of(scale, adjustedShape))
+  }
+
+  def map(input: Int): Int = {
+    if (numIndices <= 0) {
+      throw new NoSuchElementException(s"Cannot map input $input: index range [$minIndex, $maxIndex] is empty.")
+    }
+
+    if (numIndices == 1) {
+      return minIndex
+    }
+
+    val uniformValue = hashInputToUniform(input, baseSeed)
+    // clamp slightly away from exact 0.0 and 1.0 for robustness with inverse CDFs
+    val clampedUniform = math.max(Double.MinPositiveValue, math.min(uniformValue, 1.0 - Double.MinPositiveValue))
+
+    val randomIndex = distribution match {
+      case DistributionShape.Uniform =>
+        math.floor(clampedUniform * numIndices).toInt
+
+      case DistributionShape.Zipf(_, _) =>
+        underlyingDistribution match {
+          case Some(dist: ZipfDistribution) => dist.inverseCumulativeProbability(clampedUniform) - 1 // Zipf is 1-based
+          case _ => throw new IllegalStateException("ZipfDistribution not pre-calculated or invalid")
+        }
+
+      case _ =>
+        underlyingDistribution match {
+          case Some(dist: ContinuousDistribution) => math.floor(dist.inverseCumulativeProbability(clampedUniform)).toInt
+          case _ =>
+            throw new IllegalStateException(s"ContinuousDistribution not pre-calculated or invalid for $distribution")
+        }
+    }
+
+    val boundedIndex = math.max(0, math.min(randomIndex, numIndices - 1))
+
+    val finalIndex = if (distribution.shuffled.getOrElse(false)) {
+      shuffledIndices match {
+        case Some(shuffled) =>
+          // Small range: use pre-computed shuffled array for perfect distribution preservation
+          shuffled(boundedIndex)
+        case None if numIndices <= MaxStretchedElements =>
+          // Medium range: use stretched scrambling for good statistical approximation
+          stretchedScrambleIndex(boundedIndex, numIndices, input, baseSeed)
+        case None =>
+          // Large range: use direct hash scrambling
+          scrambleIndex(boundedIndex, numIndices, input, baseSeed)
+      }
+    } else {
+      boundedIndex
+    }
+
+    minIndex + finalIndex
+  }
+}

--- a/src/main/scala/akka/projection/testing/simulation/SimulationJsonFormat.scala
+++ b/src/main/scala/akka/projection/testing/simulation/SimulationJsonFormat.scala
@@ -1,0 +1,593 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.concurrent.duration._
+
+import spray.json._
+
+object SimulationJsonFormat extends DefaultJsonProtocol {
+
+  implicit val sliceFormat: JsonFormat[Slice] = new JsonFormat[Slice] {
+    override def write(slice: Slice): JsValue = JsNumber(slice.value)
+
+    override def read(json: JsValue): Slice = json match {
+      case JsNumber(value) => Slice(value.intValue)
+      case JsString(value) => Slice.parse(value)
+      case _               => deserializationError("Expected number or string for slice")
+    }
+  }
+
+  implicit val durationFormat: JsonFormat[FiniteDuration] = new JsonFormat[FiniteDuration] {
+    override def write(duration: FiniteDuration): JsValue = JsString(duration.toCoarsest.toString)
+
+    override def read(json: JsValue): FiniteDuration = json match {
+      case JsString(duration) =>
+        Duration(duration) match {
+          case finite: FiniteDuration => finite
+          case _                      => deserializationError("Expected finite duration")
+        }
+      case _ => deserializationError("Expected string for duration")
+    }
+  }
+  implicit val countFormat: JsonFormat[Count] = new JsonFormat[Count] {
+    override def write(count: Count): JsValue = JsString(count.toString)
+    override def read(json: JsValue): Count = json match {
+      case JsString(value) => Count.parse(value)
+      case JsNumber(value) => Count(value.toInt)
+      case _               => deserializationError("Expected string or number for count")
+    }
+  }
+
+  implicit val dataSizeFormat: JsonFormat[DataSize] = new JsonFormat[DataSize] {
+    override def write(size: DataSize): JsValue = JsString(size.toString)
+
+    override def read(json: JsValue): DataSize = json match {
+      case JsNumber(bytes) => DataSize(bytes.intValue.toDouble, DataUnit.Bytes)
+      case JsString(size)  => DataSize.parse(size)
+      case _               => deserializationError("Expected number or string for data size")
+    }
+  }
+
+  implicit def rangeFormat[A: Rangeable: Ordering]: JsonFormat[Range[A]] = new JsonFormat[Range[A]] {
+    override def write(range: Range[A]): JsValue = JsString(range.toString)
+
+    override def read(json: JsValue): Range[A] = json match {
+      case JsString(range) => Range.parse[A](range)
+      case _               => deserializationError("Expected string for range")
+    }
+  }
+
+  implicit def rangeMapFormat[A: Rangeable: Ordering, B: JsonFormat]: RootJsonFormat[RangeMap[A, B]] =
+    new RootJsonFormat[RangeMap[A, B]] {
+      override def write(rangeMap: RangeMap[A, B]): JsValue = {
+        val fields = rangeMap.ranges.map { case (range, value) =>
+          range.toString -> value.toJson
+        }
+        JsObject(fields.toMap)
+      }
+
+      override def read(json: JsValue): RangeMap[A, B] = {
+        json match {
+          case JsObject(fields) =>
+            val ranges = fields.map { case (key, value) =>
+              (rangeFormat.read(JsString(key)), value.convertTo[B])
+            }.toSeq
+            RangeMap(ranges: _*)
+          case _ => deserializationError("Expected object for int range map")
+        }
+      }
+    }
+
+  implicit val ratePerUnitFormat: JsonFormat[RatePerUnit] = new JsonFormat[RatePerUnit] {
+    override def write(rate: RatePerUnit): JsValue = JsString(rate.toString)
+
+    override def read(json: JsValue): RatePerUnit = json match {
+      case JsString(rate) => RatePerUnit.parse(rate)
+      case _              => deserializationError("Expected string for rate")
+    }
+  }
+
+  private object RateFunctionType {
+    val Field = "function"
+
+    val Constant = "constant"
+    val Linear = "linear"
+    val Sinusoidal = "sinusoidal"
+    val RandomWalk = "random-walk"
+    val Burst = "burst"
+    val Additive = "additive"
+    val Modulated = "modulated"
+    val Composite = "composite"
+
+    def apply(rate: RateFunctionSettings): String = rate match {
+      case _: RateFunctionSettings.ConstantSettings   => RateFunctionType.Constant
+      case _: RateFunctionSettings.LinearSettings     => RateFunctionType.Linear
+      case _: RateFunctionSettings.SinusoidalSettings => RateFunctionType.Sinusoidal
+      case _: RateFunctionSettings.RandomWalkSettings => RateFunctionType.RandomWalk
+      case _: RateFunctionSettings.BurstSettings      => RateFunctionType.Burst
+      case _: RateFunctionSettings.AdditiveSettings   => RateFunctionType.Additive
+      case _: RateFunctionSettings.ModulatedSettings  => RateFunctionType.Modulated
+      case _: RateFunctionSettings.CompositeSettings  => RateFunctionType.Composite
+    }
+  }
+
+  implicit val constantRateFunctionFormat: RootJsonFormat[RateFunctionSettings.ConstantSettings] =
+    jsonFormat1(RateFunctionSettings.ConstantSettings)
+
+  implicit val linearRateFunctionFormat: RootJsonFormat[RateFunctionSettings.LinearSettings] =
+    jsonFormat2(RateFunctionSettings.LinearSettings)
+
+  implicit val sinusoidalRateFunctionFormat: RootJsonFormat[RateFunctionSettings.SinusoidalSettings] =
+    jsonFormat4(RateFunctionSettings.SinusoidalSettings)
+
+  implicit val randomWalkRateFunctionFormat: RootJsonFormat[RateFunctionSettings.RandomWalkSettings] =
+    jsonFormat5(RateFunctionSettings.RandomWalkSettings)
+
+  implicit val burstRateFunctionFormat: RootJsonFormat[RateFunctionSettings.BurstSettings] =
+    jsonFormat6(RateFunctionSettings.BurstSettings)
+
+  implicit val additiveRateFunctionFormat: RootJsonFormat[RateFunctionSettings.AdditiveSettings] =
+    jsonFormat1(RateFunctionSettings.AdditiveSettings)
+
+  implicit val modulatedRateFunctionFormat: RootJsonFormat[RateFunctionSettings.ModulatedSettings] =
+    jsonFormat3(RateFunctionSettings.ModulatedSettings)
+
+  implicit val weightedRateFunctionFormat: RootJsonFormat[RateFunctionSettings.WeightedSettings] =
+    jsonFormat2(RateFunctionSettings.WeightedSettings)
+
+  implicit val compositeRateFunctionFormat: RootJsonFormat[RateFunctionSettings.CompositeSettings] =
+    jsonFormat1(RateFunctionSettings.CompositeSettings)
+
+  implicit def rateFunctionFormat: RootJsonFormat[RateFunctionSettings] = new RootJsonFormat[RateFunctionSettings] {
+    override def write(rateFunction: RateFunctionSettings): JsValue = rateFunction match {
+      // simplified format: constant rate can just be a string
+      case RateFunctionSettings.ConstantSettings(value) => value.toJson
+      case _ =>
+        JsObject((rateFunction match {
+          case constant: RateFunctionSettings.ConstantSettings     => constant.toJson
+          case linear: RateFunctionSettings.LinearSettings         => linear.toJson
+          case sinusoidal: RateFunctionSettings.SinusoidalSettings => sinusoidal.toJson
+          case randomWalk: RateFunctionSettings.RandomWalkSettings => randomWalk.toJson
+          case burst: RateFunctionSettings.BurstSettings           => burst.toJson
+          case additive: RateFunctionSettings.AdditiveSettings     => additive.toJson
+          case modulated: RateFunctionSettings.ModulatedSettings   => modulated.toJson
+          case composite: RateFunctionSettings.CompositeSettings   => composite.toJson
+        }).asJsObject.fields + (RateFunctionType.Field -> JsString(RateFunctionType(rateFunction))))
+    }
+
+    override def read(json: JsValue): RateFunctionSettings = json match {
+      // simplified format: just string is a constant rate
+      case jsString: JsString => RateFunctionSettings.ConstantSettings(jsString.convertTo[RatePerUnit])
+      case jsObject: JsObject =>
+        jsObject.getFields(RateFunctionType.Field) match {
+          case Seq(JsString(RateFunctionType.Constant)) => jsObject.convertTo[RateFunctionSettings.ConstantSettings]
+          case Seq(JsString(RateFunctionType.Linear))   => jsObject.convertTo[RateFunctionSettings.LinearSettings]
+          case Seq(JsString(RateFunctionType.Sinusoidal)) =>
+            jsObject.convertTo[RateFunctionSettings.SinusoidalSettings]
+          case Seq(JsString(RateFunctionType.RandomWalk)) =>
+            jsObject.convertTo[RateFunctionSettings.RandomWalkSettings]
+          case Seq(JsString(RateFunctionType.Burst))     => jsObject.convertTo[RateFunctionSettings.BurstSettings]
+          case Seq(JsString(RateFunctionType.Additive))  => jsObject.convertTo[RateFunctionSettings.AdditiveSettings]
+          case Seq(JsString(RateFunctionType.Modulated)) => jsObject.convertTo[RateFunctionSettings.ModulatedSettings]
+          case Seq(JsString(RateFunctionType.Composite)) => jsObject.convertTo[RateFunctionSettings.CompositeSettings]
+          case _                                         => deserializationError("Expected known rate function type")
+        }
+
+      case _ => deserializationError("Expected string or object for rate function")
+    }
+  }
+
+  private object PointProcess {
+    val Field = "process"
+
+    val Poisson = "poisson"
+
+    def apply(points: PointProcessSettings): String = points match {
+      case _: PointProcessSettings.PoissonSettings => PointProcess.Poisson
+    }
+  }
+
+  implicit val poissonPointsFormat: RootJsonFormat[PointProcessSettings.PoissonSettings] =
+    jsonFormat1(PointProcessSettings.PoissonSettings)
+
+  implicit val pointsFormat: RootJsonFormat[PointProcessSettings] = new RootJsonFormat[PointProcessSettings] {
+    override def write(points: PointProcessSettings): JsValue = points match {
+      // simplified format: poisson process with constant rate represented just as a rate string
+      case PointProcessSettings.PoissonSettings(RateFunctionSettings.ConstantSettings(value)) => value.toJson
+      case _ =>
+        JsObject((points match {
+          case poisson: PointProcessSettings.PoissonSettings => poisson.toJson
+        }).asJsObject.fields + (PointProcess.Field -> JsString(PointProcess(points))))
+    }
+
+    override def read(json: JsValue): PointProcessSettings = json match {
+      // simplified format: just string is treated as poisson process with constant rate
+      case jsString: JsString =>
+        PointProcessSettings.PoissonSettings(RateFunctionSettings.ConstantSettings(jsString.convertTo[RatePerUnit]))
+      case jsObject: JsObject =>
+        jsObject.getFields(PointProcess.Field) match {
+          case Seq(JsString(PointProcess.Poisson)) => jsObject.convertTo[PointProcessSettings.PoissonSettings]
+          case Nil => // no process field default to Poisson
+            if (jsObject.fields.contains("rate")) {
+              PointProcessSettings.PoissonSettings(jsObject.fields("rate").convertTo[RateFunctionSettings])
+            } else if (jsObject.fields.contains(RateFunctionType.Field)) { // assume direct rate function
+              PointProcessSettings.PoissonSettings(jsObject.convertTo[RateFunctionSettings])
+            } else {
+              deserializationError("Expected rate field or rate function fields in point process object")
+            }
+          case _ => deserializationError("Expected known points process")
+        }
+      case _ => deserializationError("Expected string or object for point process")
+    }
+  }
+
+  private object SamplerDistribution {
+    val Field = "distribution"
+
+    val Constant = "constant"
+    val Uniform = "uniform"
+    val Incremental = "incremental"
+    val Zipf = "zipf"
+    val Exponential = "exponential"
+    val Weibull = "weibull"
+    val Gamma = "gamma"
+    val LogNormal = "log-normal"
+    val Pareto = "pareto"
+    val Categorical = "categorical"
+    val Composite = "composite"
+
+    val values: Seq[String] =
+      Seq(Constant, Uniform, Zipf, Exponential, Weibull, Gamma, LogNormal, Pareto, Categorical, Composite)
+
+    def apply(sampler: SamplerSettings[_]): String = sampler match {
+      case _: SamplerSettings.ConstantSettings[_]    => SamplerDistribution.Constant
+      case _: SamplerSettings.UniformSettings[_]     => SamplerDistribution.Uniform
+      case _: SamplerSettings.IncrementalSettings[_] => SamplerDistribution.Incremental
+      case _: SamplerSettings.ZipfSettings[_]        => SamplerDistribution.Zipf
+      case _: SamplerSettings.ExponentialSettings[_] => SamplerDistribution.Exponential
+      case _: SamplerSettings.WeibullSettings[_]     => SamplerDistribution.Weibull
+      case _: SamplerSettings.GammaSettings[_]       => SamplerDistribution.Gamma
+      case _: SamplerSettings.LogNormalSettings[_]   => SamplerDistribution.LogNormal
+      case _: SamplerSettings.ParetoSettings[_]      => SamplerDistribution.Pareto
+      case _: SamplerSettings.CategoricalSettings[_] => SamplerDistribution.Categorical
+      case _: SamplerSettings.CompositeSettings[_]   => SamplerDistribution.Composite
+    }
+  }
+
+  implicit def constantSamplerFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings.ConstantSettings[A]] =
+    jsonFormat1(SamplerSettings.ConstantSettings[A])
+
+  implicit def uniformSamplerFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings.UniformSettings[A]] =
+    jsonFormat2(SamplerSettings.UniformSettings[A])
+
+  implicit def incrementalSamplerFormat[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.IncrementalSettings[A]] =
+    jsonFormat3(SamplerSettings.IncrementalSettings[A])
+
+  implicit def zipfSamplerFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings.ZipfSettings[A]] =
+    jsonFormat4(SamplerSettings.ZipfSettings[A])
+
+  implicit def exponentialSamplerFormat[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.ExponentialSettings[A]] =
+    jsonFormat4(SamplerSettings.ExponentialSettings[A])
+
+  implicit def weibullSamplerFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings.WeibullSettings[A]] =
+    jsonFormat5(SamplerSettings.WeibullSettings[A])
+
+  implicit def gammaSamplerFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings.GammaSettings[A]] =
+    jsonFormat5(SamplerSettings.GammaSettings[A])
+
+  implicit def muSigmaFormat[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.LogNormalSettings.MuSigmaSettings[A]] =
+    jsonFormat5(SamplerSettings.LogNormalSettings.MuSigmaSettings[A])
+
+  implicit def scaleShapeFormat[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.LogNormalSettings.ScaleShapeSettings[A]] =
+    jsonFormat5(SamplerSettings.LogNormalSettings.ScaleShapeSettings[A])
+
+  implicit def meanStdDevFormat[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.LogNormalSettings.MeanStdDevSettings[A]] =
+    jsonFormat5(SamplerSettings.LogNormalSettings.MeanStdDevSettings[A])
+
+  implicit def medianP95Format[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.LogNormalSettings.MedianP95Settings[A]] =
+    jsonFormat5(SamplerSettings.LogNormalSettings.MedianP95Settings[A])
+
+  implicit def logNormalSamplerFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings.LogNormalSettings[A]] =
+    new RootJsonFormat[SamplerSettings.LogNormalSettings[A]] {
+      override def write(settings: SamplerSettings.LogNormalSettings[A]): JsValue = {
+        settings match {
+          case s: SamplerSettings.LogNormalSettings.MuSigmaSettings[A]    => muSigmaFormat[A].write(s)
+          case s: SamplerSettings.LogNormalSettings.ScaleShapeSettings[A] => scaleShapeFormat[A].write(s)
+          case s: SamplerSettings.LogNormalSettings.MeanStdDevSettings[A] => meanStdDevFormat[A].write(s)
+          case s: SamplerSettings.LogNormalSettings.MedianP95Settings[A]  => medianP95Format[A].write(s)
+        }
+      }
+
+      override def read(json: JsValue): SamplerSettings.LogNormalSettings[A] = {
+        val fields = json.asJsObject.fields
+
+        if (fields.contains("mu") && fields.contains("sigma")) {
+          muSigmaFormat[A].read(json)
+        } else if (fields.contains("scale") && fields.contains("shape")) {
+          scaleShapeFormat[A].read(json)
+        } else if (fields.contains("mean") && fields.contains("stdDev")) {
+          meanStdDevFormat[A].read(json)
+        } else if (fields.contains("median") && fields.contains("p95")) {
+          medianP95Format[A].read(json)
+        } else {
+          throw deserializationError(
+            "Unknown log-normal parameters - must include pairs: mu/sigma, scale/shape, mean/stdDev, or median/p95")
+        }
+      }
+    }
+
+  implicit def paretoScaleShapeFormat[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.ParetoSettings.ScaleShapeSettings[A]] =
+    jsonFormat4(SamplerSettings.ParetoSettings.ScaleShapeSettings[A])
+
+  implicit def paretoMinP95Format[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.ParetoSettings.MinP95Settings[A]] =
+    jsonFormat4(SamplerSettings.ParetoSettings.MinP95Settings[A])
+
+  implicit def paretoSamplerFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings.ParetoSettings[A]] =
+    new RootJsonFormat[SamplerSettings.ParetoSettings[A]] {
+      override def write(settings: SamplerSettings.ParetoSettings[A]): JsValue = {
+        settings match {
+          case s: SamplerSettings.ParetoSettings.ScaleShapeSettings[A] => paretoScaleShapeFormat[A].write(s)
+          case s: SamplerSettings.ParetoSettings.MinP95Settings[A]     => paretoMinP95Format[A].write(s)
+        }
+      }
+
+      override def read(json: JsValue): SamplerSettings.ParetoSettings[A] = {
+        val fields = json.asJsObject.fields
+
+        if (fields.contains("scale") && fields.contains("shape")) {
+          paretoScaleShapeFormat[A].read(json)
+        } else if (fields.contains("min") && fields.contains("p95")) {
+          paretoMinP95Format[A].read(json)
+        } else {
+          throw deserializationError("Unknown Pareto parameters - must include pairs: scale/shape or min/p95")
+        }
+      }
+    }
+
+  implicit def categoryFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings.CategorySettings[A]] =
+    jsonFormat2(SamplerSettings.CategorySettings[A])
+
+  implicit def categoricalSamplerFormat[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.CategoricalSettings[A]] =
+    jsonFormat1(SamplerSettings.CategoricalSettings[A])
+
+  implicit def weightedSamplerFormat[A: Sampled: JsonFormat]
+      : RootJsonFormat[SamplerSettings.WeightedSamplerSettings[A]] =
+    new RootJsonFormat[SamplerSettings.WeightedSamplerSettings[A]] {
+      override def write(obj: SamplerSettings.WeightedSamplerSettings[A]): JsValue =
+        JsObject("sampler" -> samplerFormat[A].write(obj.sampler), "weight" -> JsNumber(obj.weight))
+
+      override def read(json: JsValue): SamplerSettings.WeightedSamplerSettings[A] = {
+        val fields = json.asJsObject.fields
+        SamplerSettings.WeightedSamplerSettings(
+          samplerFormat[A].read(fields("sampler")),
+          fields("weight").convertTo[Double])
+      }
+    }
+
+  implicit def compositeSamplerFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings.CompositeSettings[A]] =
+    jsonFormat1(SamplerSettings.CompositeSettings[A])
+
+  implicit def samplerFormat[A: Sampled: JsonFormat]: RootJsonFormat[SamplerSettings[A]] =
+    new RootJsonFormat[SamplerSettings[A]] {
+      override def write(sampler: SamplerSettings[A]): JsValue = sampler match {
+        // simplified format: constant samplers are just their value directly
+        case SamplerSettings.ConstantSettings(value) => implicitly[JsonFormat[A]].write(value)
+        case _ =>
+          val baseJson = sampler match {
+            case s: SamplerSettings.ConstantSettings[A]    => constantSamplerFormat[A].write(s)
+            case s: SamplerSettings.UniformSettings[A]     => uniformSamplerFormat[A].write(s)
+            case s: SamplerSettings.IncrementalSettings[A] => incrementalSamplerFormat[A].write(s)
+            case s: SamplerSettings.ZipfSettings[A]        => zipfSamplerFormat[A].write(s)
+            case s: SamplerSettings.ExponentialSettings[A] => exponentialSamplerFormat[A].write(s)
+            case s: SamplerSettings.WeibullSettings[A]     => weibullSamplerFormat[A].write(s)
+            case s: SamplerSettings.GammaSettings[A]       => gammaSamplerFormat[A].write(s)
+            case s: SamplerSettings.LogNormalSettings[A]   => logNormalSamplerFormat[A].write(s)
+            case s: SamplerSettings.ParetoSettings[A]      => paretoSamplerFormat[A].write(s)
+            case s: SamplerSettings.CategoricalSettings[A] => categoricalSamplerFormat[A].write(s)
+            case s: SamplerSettings.CompositeSettings[A]   => compositeSamplerFormat[A].write(s)
+          }
+          JsObject(baseJson.asJsObject.fields + (SamplerDistribution.Field -> JsString(SamplerDistribution(sampler))))
+      }
+
+      override def read(json: JsValue): SamplerSettings[A] = json match {
+        // simplified format: constant values create a constant sampler directly
+        case value if !value.isInstanceOf[JsObject] => SamplerSettings.ConstantSettings[A](value.convertTo[A])
+        case jsObject: JsObject                     =>
+          // special handling for count shorthand for uniform distribution
+          jsObject.getFields("count") match {
+            case Seq(countValue) if implicitly[Sampled[A]].isDiscrete =>
+              // If 'count' is present and we're working with a discrete type, create a uniform distribution from 1 to count
+              val count = countValue match {
+                case JsString(s) => Count.parse(s).toInt
+                case JsNumber(n) => n.toInt
+                case _ => deserializationError(s"Expected count to be a number or count string, got: $countValue")
+              }
+
+              val discrete = implicitly[Sampled[A]] match {
+                case Sampled.Discrete(value) => value
+                case _ => deserializationError("Count shorthand can only be used with discrete types")
+              }
+
+              SamplerSettings.UniformSettings[A](discrete.fromInt(1), discrete.fromInt(count))
+            case _ =>
+              // Regular processing for non-count fields
+              jsObject.getFields(SamplerDistribution.Field) match {
+                case Seq(JsString(SamplerDistribution.Constant)) =>
+                  constantSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.Uniform)) =>
+                  uniformSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.Incremental)) =>
+                  incrementalSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.Zipf)) =>
+                  zipfSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.Exponential)) =>
+                  exponentialSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.Weibull)) =>
+                  weibullSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.Gamma)) =>
+                  gammaSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.LogNormal)) =>
+                  logNormalSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.Pareto)) =>
+                  paretoSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.Categorical)) =>
+                  categoricalSamplerFormat[A].read(jsObject)
+                case Seq(JsString(SamplerDistribution.Composite)) =>
+                  compositeSamplerFormat[A].read(jsObject)
+                case _ =>
+                  deserializationError(
+                    s"Unknown sampler distribution type: expected one of: ${SamplerDistribution.values.mkString(", ")}")
+              }
+          }
+        case _ => deserializationError("Expected primitive value or object for sampler")
+      }
+    }
+
+  private object DistributionShapeType {
+    val Field = "type"
+
+    val Uniform = "uniform"
+    val Zipf = "zipf"
+    val Exponential = "exponential"
+    val Weibull = "weibull"
+    val Gamma = "gamma"
+    val LogNormal = "log-normal"
+    val Pareto = "pareto"
+
+    val values: Seq[String] = Seq(Uniform, Zipf, Exponential, Weibull, Gamma, LogNormal, Pareto)
+
+    def apply(shape: DistributionShape): String = shape match {
+      case DistributionShape.Uniform        => Uniform
+      case _: DistributionShape.Zipf        => Zipf
+      case _: DistributionShape.Exponential => Exponential
+      case _: DistributionShape.Weibull     => Weibull
+      case _: DistributionShape.Gamma       => Gamma
+      case _: DistributionShape.LogNormal   => LogNormal
+      case _: DistributionShape.Pareto      => Pareto
+    }
+  }
+
+  implicit val exponentialDistributionShapeFormat: RootJsonFormat[DistributionShape.Exponential] =
+    jsonFormat1(DistributionShape.Exponential)
+
+  implicit val zipfDistributionShapeFormat: RootJsonFormat[DistributionShape.Zipf] =
+    jsonFormat2(DistributionShape.Zipf)
+
+  implicit val weibullDistributionShapeFormat: RootJsonFormat[DistributionShape.Weibull] =
+    jsonFormat2(DistributionShape.Weibull)
+
+  implicit val gammaDistributionShapeFormat: RootJsonFormat[DistributionShape.Gamma] =
+    jsonFormat2(DistributionShape.Gamma)
+
+  implicit val logNormalDistributionShapeFormat: RootJsonFormat[DistributionShape.LogNormal] =
+    jsonFormat2(DistributionShape.LogNormal)
+
+  implicit val paretoDistributionShapeFormat: RootJsonFormat[DistributionShape.Pareto] =
+    jsonFormat2(DistributionShape.Pareto)
+
+  implicit val distributionShapeFormat: RootJsonFormat[DistributionShape] = new RootJsonFormat[DistributionShape] {
+    override def write(shape: DistributionShape): JsValue = {
+      val baseJson = shape match {
+        case DistributionShape.Uniform                  => JsObject()
+        case zipf: DistributionShape.Zipf               => zipf.toJson.asJsObject
+        case exponential: DistributionShape.Exponential => exponential.toJson.asJsObject
+        case weibull: DistributionShape.Weibull         => weibull.toJson.asJsObject
+        case gamma: DistributionShape.Gamma             => gamma.toJson.asJsObject
+        case logNormal: DistributionShape.LogNormal     => logNormal.toJson.asJsObject
+        case pareto: DistributionShape.Pareto           => pareto.toJson.asJsObject
+      }
+      JsObject(baseJson.fields + (DistributionShapeType.Field -> JsString(DistributionShapeType(shape))))
+    }
+
+    override def read(json: JsValue): DistributionShape = {
+      json.asJsObject.getFields(DistributionShapeType.Field) match {
+        case Seq(JsString(DistributionShapeType.Uniform))     => DistributionShape.Uniform
+        case Seq(JsString(DistributionShapeType.Zipf))        => zipfDistributionShapeFormat.read(json)
+        case Seq(JsString(DistributionShapeType.Exponential)) => exponentialDistributionShapeFormat.read(json)
+        case Seq(JsString(DistributionShapeType.Weibull))     => weibullDistributionShapeFormat.read(json)
+        case Seq(JsString(DistributionShapeType.Gamma))       => gammaDistributionShapeFormat.read(json)
+        case Seq(JsString(DistributionShapeType.LogNormal))   => logNormalDistributionShapeFormat.read(json)
+        case Seq(JsString(DistributionShapeType.Pareto))      => paretoDistributionShapeFormat.read(json)
+        case _ =>
+          deserializationError(
+            s"Unknown distribution shape type: expected one of: ${DistributionShapeType.values.mkString(", ")}")
+      }
+    }
+  }
+
+  implicit val entityIdFormat: RootJsonFormat[EntityIdSettings] = jsonFormat3(EntityIdSettings)
+
+  implicit val eventFormat: RootJsonFormat[EventSettings] = jsonFormat2(EventSettings)
+
+  implicit val activityPerEntityFormat: RootJsonFormat[ActivitySettings.PerEntitySettings] =
+    jsonFormat2(ActivitySettings.PerEntitySettings)
+
+  // support both the nested perEntity format, and flattened version which creates default range map
+  implicit val activityPerSliceFormat: RootJsonFormat[ActivitySettings.PerSliceSettings] =
+    new RootJsonFormat[ActivitySettings.PerSliceSettings] {
+      // always write the fully nested format
+      override def write(perSlice: ActivitySettings.PerSliceSettings): JsValue = {
+        JsObject("perEntity" -> perSlice.perEntity.toJson)
+      }
+
+      override def read(json: JsValue): ActivitySettings.PerSliceSettings = {
+        val fields = json.asJsObject.fields
+
+        if (fields.contains("perEntity")) { // nested format for entities
+          val perEntity = fields("perEntity").convertTo[RangeMap[Int, ActivitySettings.PerEntitySettings]]
+          ActivitySettings.PerSliceSettings(perEntity)
+        } else { // flattened format
+          val duration = fields("duration").convertTo[SamplerSettings[FiniteDuration]]
+          val event = fields("event").convertTo[EventSettings]
+          val perEntitySettings = ActivitySettings.PerEntitySettings(duration, event)
+          val perEntity = RangeMap(Range.Default -> perEntitySettings)
+          ActivitySettings.PerSliceSettings(perEntity)
+        }
+      }
+    }
+
+  // support both the nested perSlice / perEntity format, and flattened versions which create default range maps
+  implicit val activityFormat: RootJsonFormat[ActivitySettings] = new RootJsonFormat[ActivitySettings] {
+    // always write the fully nested format
+    override def write(settings: ActivitySettings): JsValue = {
+      JsObject("frequency" -> settings.frequency.toJson, "perSlice" -> settings.perSlice.toJson)
+    }
+
+    override def read(json: JsValue): ActivitySettings = {
+      val fields = json.asJsObject.fields
+
+      val frequency = fields("frequency").convertTo[PointProcessSettings]
+
+      if (fields.contains("perSlice")) { // nested format for slices
+        val perSlice = fields("perSlice").convertTo[RangeMap[Slice, ActivitySettings.PerSliceSettings]]
+        ActivitySettings(frequency, perSlice)
+      } else { // flattened format for slices
+        val perSliceSettings = json.convertTo[ActivitySettings.PerSliceSettings]
+        val perSlice = RangeMap[Slice, ActivitySettings.PerSliceSettings](Range.Default -> perSliceSettings)
+        ActivitySettings(frequency, perSlice)
+      }
+    }
+  }
+
+  implicit val randomFormat: RootJsonFormat[RandomSettings] = jsonFormat2(RandomSettings)
+
+  implicit val generatorFormat: RootJsonFormat[GeneratorSettings] = jsonFormat3(GeneratorSettings)
+
+  implicit val stageFormat: RootJsonFormat[StageSettings] = jsonFormat4(StageSettings)
+
+  implicit val engineFormat: RootJsonFormat[EngineSettings] = jsonFormat4(EngineSettings)
+
+  implicit val simulationFormat: RootJsonFormat[SimulationSettings] = jsonFormat4(SimulationSettings)
+}

--- a/src/main/scala/akka/projection/testing/simulation/SimulationSettings.scala
+++ b/src/main/scala/akka/projection/testing/simulation/SimulationSettings.scala
@@ -1,0 +1,839 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.concurrent.duration._
+
+/**
+ * Simulation configuration.
+ *
+ * @param name
+ *   Optional name for this simulation for identification
+ * @param description
+ *   Optional description for this simulation
+ * @param stages
+ *   Sequence of stage configurations that will be executed sequentially
+ * @param engine
+ *   Optional settings for the simulation execution engine
+ */
+final case class SimulationSettings(
+    name: Option[String],
+    description: Option[String],
+    stages: Seq[StageSettings],
+    engine: Option[EngineSettings])
+
+/**
+ * Settings for a simulation stage. Stages are executed sequentially in the order they are defined.
+ *
+ * @param name
+ *   Optional name for this stage for identification
+ * @param duration
+ *   Total runtime for this stage
+ * @param delay
+ *   Optional delay before this stage starts (relative to the end of the previous stage)
+ * @param generators
+ *   Generator configurations controlling workload creation for this stage
+ */
+final case class StageSettings(
+    name: Option[String],
+    duration: FiniteDuration,
+    delay: Option[FiniteDuration],
+    generators: Seq[GeneratorSettings])
+
+/**
+ * Settings that control a specific workload generator's behavior.
+ *
+ * @param entityId
+ *   Configuration for the entity access patterns
+ * @param activity
+ *   Configuration for the activity patterns
+ * @param random
+ *   Optional random number generator settings
+ */
+final case class GeneratorSettings(
+    entityId: EntityIdSettings,
+    activity: ActivitySettings,
+    random: Option[RandomSettings])
+
+/**
+ * Configuration for entity access patterns in the simulation.
+ *
+ * @param entity
+ *   Sampler settings for selecting entities
+ * @param slices
+ *   Optional range of slices that the entities are distributed over, otherwise all slices
+ * @param sliceDistribution
+ *   Optional distribution shape for assigning slices to entities, otherwise uniform
+ */
+final case class EntityIdSettings(
+    entity: SamplerSettings[Int],
+    slices: Option[Range[Slice]],
+    sliceDistribution: Option[DistributionShape])
+
+/**
+ * Configuration for activity patterns in the simulation.
+ *
+ * @param frequency
+ *   Frequency of new activities
+ * @param perSlice
+ *   Mapping of slices to their respective settings
+ */
+final case class ActivitySettings(
+    frequency: PointProcessSettings,
+    perSlice: RangeMap[Slice, ActivitySettings.PerSliceSettings])
+
+object ActivitySettings {
+
+  /**
+   * Activity settings for a specific slice.
+   *
+   * @param perEntity
+   *   Mapping of entity indices to their respective settings
+   */
+  final case class PerSliceSettings(perEntity: RangeMap[Int, PerEntitySettings])
+
+  /**
+   * Activity settings for a specific entity.
+   *
+   * @param duration
+   *   Sampler for how long the activity with the entity lasts
+   * @param event
+   *   Configuration for event generation during an activity.
+   */
+  final case class PerEntitySettings(duration: SamplerSettings[FiniteDuration], event: EventSettings)
+}
+
+/**
+ * Settings for event generation during an activity.
+ *
+ * @param frequency
+ *   Frequency of events in an activity
+ * @param dataSize
+ *   Data size for each generated event
+ */
+final case class EventSettings(frequency: PointProcessSettings, dataSize: SamplerSettings[DataSize])
+
+/**
+ * Configuration for random number generation.
+ *
+ * @param algorithm
+ *   Optional random algorithm specification (from Apache Commons random sources)
+ * @param seed
+ *   Optional seed value for deterministic randomization
+ */
+final case class RandomSettings(algorithm: Option[String], seed: Option[Long])
+
+/**
+ * Settings for the simulation execution engine.
+ *
+ * @param tick
+ *   Time interval for simulation clock advancement
+ * @param parallelism
+ *   Degree of parallel execution
+ * @param ackPersists
+ *   Whether to wait for acknowledge for entity persists
+ * @param validationTimeout
+ *   Timeout for projection validation after simulation completes
+ */
+final case class EngineSettings(
+    tick: Option[FiniteDuration],
+    parallelism: Option[Int],
+    ackPersists: Option[Boolean],
+    validationTimeout: Option[FiniteDuration])
+
+/**
+ * Settings that define the behavior of a point process (the occurrence of discrete events in continuous time).
+ */
+sealed trait PointProcessSettings
+
+object PointProcessSettings {
+
+  /**
+   * Settings for a Poisson point process, where events occur continuously and independently.
+   *
+   * @param rate
+   *   The rate function settings that determine how the intensity changes over time
+   */
+  final case class PoissonSettings(rate: RateFunctionSettings) extends PointProcessSettings
+}
+
+/**
+ * Settings that define the rate function behavior for point processes.
+ *
+ * The rate function determines the intensity of events over time.
+ */
+sealed trait RateFunctionSettings
+
+object RateFunctionSettings {
+
+  /**
+   * Constant rate that doesn't change over time.
+   *
+   * @param value
+   *   The fixed rate at which events occur
+   */
+  final case class ConstantSettings(value: RatePerUnit) extends RateFunctionSettings
+
+  /**
+   * Linear rate function that interpolates between initial and target rates over time.
+   *
+   * @param initial
+   *   The rate at the beginning of the time period
+   * @param target
+   *   The rate at the end of the time period
+   */
+  final case class LinearSettings(initial: RatePerUnit, target: RatePerUnit) extends RateFunctionSettings
+
+  /**
+   * Sinusoidal rate function that oscillates around a base rate.
+   *
+   * @param base
+   *   The center rate around which oscillation occurs
+   * @param amplitude
+   *   The maximum deviation from the base rate
+   * @param period
+   *   The time taken for one complete oscillation
+   * @param shift
+   *   The time offset for the wave pattern
+   */
+  final case class SinusoidalSettings(
+      base: RatePerUnit,
+      amplitude: RatePerUnit,
+      period: FiniteDuration,
+      shift: Option[FiniteDuration])
+      extends RateFunctionSettings
+
+  /**
+   * Random walk rate that models stochastic fluctuations within bounds.
+   *
+   * @param initial
+   *   The starting rate
+   * @param min
+   *   The minimum allowed rate
+   * @param max
+   *   The maximum allowed rate
+   * @param volatility
+   *   The magnitude of random fluctuations
+   * @param trend
+   *   Optional directional bias (positive values create an upward trend, while negative values create a downward trend)
+   */
+  final case class RandomWalkSettings(
+      initial: RatePerUnit,
+      min: RatePerUnit,
+      max: RatePerUnit,
+      volatility: Double,
+      trend: Option[Double])
+      extends RateFunctionSettings
+
+  /**
+   * Burst rate function that simulates temporary spikes in activity.
+   *
+   * @param base
+   *   The normal background rate
+   * @param peak
+   *   The maximum rate during the burst
+   * @param start
+   *   When the burst begins after simulation start
+   * @param rampUp
+   *   Duration over which rate increases to peak
+   * @param burst
+   *   Duration at peak rate
+   * @param rampDown
+   *   Duration over which rate returns to base
+   */
+  final case class BurstSettings(
+      base: RatePerUnit,
+      peak: RatePerUnit,
+      start: FiniteDuration,
+      rampUp: FiniteDuration,
+      burst: FiniteDuration,
+      rampDown: FiniteDuration)
+      extends RateFunctionSettings
+
+  /**
+   * Additive combination of multiple rate functions. The resulting rate is the sum of all component rates.
+   *
+   * @param additiveRates
+   *   Rate functions to combine by addition
+   */
+  final case class AdditiveSettings(additiveRates: Seq[RateFunctionSettings]) extends RateFunctionSettings
+
+  /**
+   * Modulated rate function where one function modulates another. The carrier rate is multiplied by a modulation factor
+   * derived from the modulator.
+   *
+   * @param carrier
+   *   The primary rate function
+   * @param modulator
+   *   The rate function that provides modulation
+   * @param strength
+   *   Optional intensity of modulation (0.0 = no modulation, 1.0 = full modulation)
+   */
+  final case class ModulatedSettings(
+      carrier: RateFunctionSettings,
+      modulator: RateFunctionSettings,
+      strength: Option[Double])
+      extends RateFunctionSettings
+
+  /**
+   * Weighted combination of multiple rate functions. The resulting rate is a weighted average of component rates.
+   *
+   * @param compositeRates
+   *   A sequence of weighted rate function settings, each with a relative probability weight.
+   */
+  final case class CompositeSettings(compositeRates: Seq[WeightedSettings]) extends RateFunctionSettings
+
+  /**
+   * Defines a rate function with its relative weight for use in composite rate function.
+   *
+   * @param rate
+   *   The rate function settings to use
+   * @param weight
+   *   The relative weight for this rate function's contribution to the composite rate function.
+   */
+  final case class WeightedSettings(rate: RateFunctionSettings, weight: Double)
+}
+
+/**
+ * Settings that define how values are sampled from various probability distributions.
+ *
+ * The specific type determines the distribution's shape, parameters, and constraints.
+ *
+ * @tparam Value
+ *   The type of value that will be generated by the sampler
+ */
+sealed trait SamplerSettings[Value] {
+
+  /**
+   * Applies shuffling to a discrete sampler.
+   *
+   * Shuffling is most meaningful for distributions where values have different probabilities (like Zipf or exponential)
+   * and is not supported for distributions where values already have equal probability (uniform) or are constant.
+   */
+  def shuffled: Option[Boolean]
+}
+
+object SamplerSettings {
+
+  /**
+   * Constant sampler that always returns the same value.
+   *
+   * @param value
+   *   The fixed value that will always be returned
+   */
+  final case class ConstantSettings[Value: Sampled](value: Value) extends SamplerSettings[Value] {
+    override def shuffled: Option[Boolean] = None
+  }
+
+  /**
+   * Uniform distribution settings where all values within the specified range have equal probability.
+   *
+   * @param min
+   *   The minimum value (inclusive) that can be generated
+   * @param max
+   *   The maximum value (inclusive) that can be generated
+   */
+  final case class UniformSettings[Value: Sampled](min: Value, max: Value) extends SamplerSettings[Value] {
+    override def shuffled: Option[Boolean] = None
+  }
+
+  /**
+   * Incremental sampler settings.
+   *
+   * @param start
+   *   The starting value for the counter.
+   * @param step
+   *   The step value by which the counter is incremented.
+   * @param limit
+   *   Optional limit value. If set, the counter will cycle back to the start value once the limit is reached.
+   */
+  final case class IncrementalSettings[Value: Sampled](start: Value, step: Value, limit: Option[Value] = None)
+      extends SamplerSettings[Value] {
+    override def shuffled: Option[Boolean] = None
+  }
+
+  /**
+   * Zipf distribution settings for modeling power-law relationships.
+   *
+   * In a Zipf distribution, the frequency of an item is inversely proportional to its rank. This is commonly used to
+   * model real-world phenomena where a small number of items occur with high frequency while most items occur rarely.
+   *
+   * @param min
+   *   The minimum value (inclusive) that can be generated
+   *
+   * @param max
+   *   The maximum value (inclusive) that can be generated
+   *
+   * @param exponent
+   *   Controls the "steepness" of the distribution. Higher values create more skewed distributions where the
+   *   highest-ranked items occur much more frequently than others. Typical values range from 1.0 to 3.0, with 1.0 being
+   *   classic Zipf's law.
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to rank
+   *   (i.e., the smallest values shouldn't necessarily be the most common). Default is false.
+   */
+  final case class ZipfSettings[Value: Sampled](
+      min: Value,
+      max: Value,
+      exponent: Double,
+      shuffled: Option[Boolean] = None)
+      extends SamplerSettings[Value]
+
+  /**
+   * Exponential distribution settings.
+   *
+   * When applied to discrete samplers, generated values will be rounded to the nearest integer.
+   *
+   * @param mean
+   *   The mean (average) value
+   *
+   * @param min
+   *   Optional minimum value bound (inclusive). For discrete samplers, setting a reasonable minimum can be useful as
+   *   the exponential distribution technically includes very small values.
+   *
+   * @param max
+   *   Optional maximum value bound (inclusive). For discrete samplers, setting a reasonable maximum prevents the
+   *   occasional very large values that the distribution can theoretically generate.
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to value.
+   */
+  final case class ExponentialSettings[Value: Sampled](
+      mean: Value,
+      min: Option[Value] = None,
+      max: Option[Value] = None,
+      shuffled: Option[Boolean] = None)
+      extends SamplerSettings[Value]
+
+  /**
+   * Weibull distribution settings. Versatile for modeling values with different variability patterns.
+   *
+   * When applied to discrete samplers, generated values will be rounded to the nearest integer.
+   *
+   * @param shape
+   *   The shape parameter (k) that determines the distribution's behavior:
+   *   - shape < 1: decreasing rate (many smaller values, with long tails)
+   *   - shape = 1: constant rate (equivalent to exponential distribution)
+   *   - shape > 1: increasing rate (samples cluster around the characteristic value)
+   *   - shape ≈ 3.5: approximates normal distribution (symmetric around the mean)
+   *
+   * @param scale
+   *   The scale parameter (λ) that determines the characteristic scale of the distribution
+   *
+   * @param min
+   *   Optional minimum value bound (inclusive). For discrete samplers, provides a lower truncation point.
+   *
+   * @param max
+   *   Optional maximum value bound (inclusive). For discrete samplers, provides an upper truncation point.
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to value.
+   */
+  final case class WeibullSettings[Value: Sampled](
+      shape: Double,
+      scale: Value,
+      min: Option[Value] = None,
+      max: Option[Value] = None,
+      shuffled: Option[Boolean] = None)
+      extends SamplerSettings[Value]
+
+  /**
+   * Gamma distribution settings. Good for modeling the sum of exponential random variables.
+   *
+   * When applied to discrete samplers, generated values will be rounded to the nearest integer.
+   *
+   * @param shape
+   *   The shape parameter (k) that controls the basic form of the distribution
+   *
+   * @param scale
+   *   The scale parameter (θ) that stretches or compresses the distribution
+   *
+   * @param min
+   *   Optional minimum value bound (inclusive)
+   *
+   * @param max
+   *   Optional maximum value bound (inclusive)
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to value.
+   */
+  final case class GammaSettings[Value: Sampled](
+      shape: Double,
+      scale: Value,
+      min: Option[Value] = None,
+      max: Option[Value] = None,
+      shuffled: Option[Boolean] = None)
+      extends SamplerSettings[Value]
+
+  /**
+   * Log-normal distribution settings.
+   *
+   * Useful for modelling values with positive skew, where most are clustered around a central value but with a long
+   * tail of occasional larger values. When applied to discrete samplers, generated values will be rounded to the
+   * nearest integer.
+   */
+  sealed trait LogNormalSettings[Value] extends SamplerSettings[Value] {
+    def min: Option[Value]
+    def max: Option[Value]
+  }
+
+  object LogNormalSettings {
+
+    /**
+     * Log-normal distribution parameters using direct mathematical parameters μ (mu) and σ (sigma).
+     *
+     * @param mu
+     *   Location parameter of the log-normal distribution (mean in log-space). This is a dimensionless quantity that
+     *   affects the scale of the distribution.
+     *
+     * @param sigma
+     *   The shape parameter of the log-normal distribution (standard deviation in log-space). Controls the
+     *   spread/dispersion of the distribution:
+     *   - Small values (< 0.25): distribution is nearly symmetric
+     *   - Medium values (0.25-0.5): moderate right skew
+     *   - Large values (> 1.0): heavy right skew with extreme values
+     *
+     * @param min
+     *   Optional minimum value bound (inclusive)
+     *
+     * @param max
+     *   Optional maximum value bound (inclusive)
+     *
+     * @param shuffled
+     *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes
+     *   the values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to
+     *   value.
+     */
+    final case class MuSigmaSettings[Value: Sampled](
+        mu: Double,
+        sigma: Double,
+        min: Option[Value] = None,
+        max: Option[Value] = None,
+        shuffled: Option[Boolean] = None)
+        extends LogNormalSettings[Value]
+
+    /**
+     * Log-normal distribution parameters using a scale-shape parameterization.
+     *
+     * Note: scale defines "where" the distribution is centered, while shape defines "how spread out" it is.
+     *
+     * @param scale
+     *   The scale parameter (`e^μ`), which equals the median of the distribution. This parameter sets the central
+     *   tendency of the distribution.
+     *
+     * @param shape
+     *   The shape parameter (σ), which is the standard deviation in logarithmic space. Higher values create more
+     *   dispersed distributions with heavier tails.
+     *   - shape ≈ 0.1: very tight distribution close to the median
+     *   - shape ≈ 0.5: moderate variation around the median
+     *   - shape ≈ 1.0: substantial variation with many extreme values
+     *
+     * @param min
+     *   Optional minimum value bound (inclusive)
+     *
+     * @param max
+     *   Optional maximum value bound (inclusive)
+     *
+     * @param shuffled
+     *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes
+     *   the values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to
+     *   value.
+     */
+    final case class ScaleShapeSettings[Value: Sampled](
+        scale: Value,
+        shape: Double,
+        min: Option[Value] = None,
+        max: Option[Value] = None,
+        shuffled: Option[Boolean] = None)
+        extends LogNormalSettings[Value]
+
+    /**
+     * Log-normal distribution parameters defined by arithmetic mean and standard deviation.
+     *
+     * @param mean
+     *   The arithmetic mean of the distribution. Note that this is not the same as the median due to the skewed nature
+     *   of log-normal distributions. The mean is always larger than the median.
+     *
+     * @param stdDev
+     *   The standard deviation, which measures the amount of variation in the distribution. Larger values create more
+     *   variable distributions.
+     *
+     * @param min
+     *   Optional minimum value bound (inclusive)
+     *
+     * @param max
+     *   Optional maximum value bound (inclusive)
+     *
+     * @param shuffled
+     *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes
+     *   the values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to
+     *   value.
+     */
+    final case class MeanStdDevSettings[Value: Sampled](
+        mean: Value,
+        stdDev: Value,
+        min: Option[Value] = None,
+        max: Option[Value] = None,
+        shuffled: Option[Boolean] = None)
+        extends LogNormalSettings[Value]
+
+    /**
+     * Log-normal distribution parameters defined by median (50th percentile) and 95th percentile values.
+     *
+     * Note: useful for modeling by defining the "normal" case (median) and "almost maximum" (p95) scenarios.
+     *
+     * @param median
+     *   The median value (50th percentile) - half of all generated values will be below this
+     *
+     * @param p95
+     *   The 95th percentile value - 95% of all generated values will be below this
+     *
+     * @param min
+     *   Optional minimum value bound (inclusive). If not specified, defaults to 0 for discrete samplers.
+     *
+     * @param max
+     *   Optional maximum value bound (inclusive). If not specified, allows for occasional very large values.
+     *
+     * @param shuffled
+     *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes
+     *   the values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to
+     *   value.
+     */
+    final case class MedianP95Settings[Value: Sampled](
+        median: Value,
+        p95: Value,
+        min: Option[Value] = None,
+        max: Option[Value] = None,
+        shuffled: Option[Boolean] = None)
+        extends LogNormalSettings[Value]
+  }
+
+  /**
+   * Pareto distribution settings.
+   *
+   * Useful for modelling heavy-tailed samples following power-law behavior ("80/20 rule"), where a small percentage of
+   * values are disproportionately larger. When applied to discrete samplers, generated values will be rounded to the
+   * nearest integer.
+   */
+  sealed trait ParetoSettings[Value] extends SamplerSettings[Value] {
+
+    /** Optional maximum value bound (inclusive) */
+    def max: Option[Value]
+  }
+
+  object ParetoSettings {
+
+    /**
+     * Pareto distribution parameters using scale and shape.
+     *
+     * @param scale
+     *   The scale parameter (xm), minimum possible value.
+     *
+     * @param shape
+     *   The shape parameter (α), controlling the tail heaviness (Pareto index).
+     *   - shape ≈ 1.1-1.5: Extremely heavy tail (many extreme outliers)
+     *   - shape ≈ 1.5-2.0: Heavy tail (classic 80/20 rule)
+     *   - shape > 2.0: Moderate tail with fewer extreme outliers
+     *   - Must be greater than 1 for the distribution to have a finite mean
+     *
+     * @param max
+     *   Optional maximum value bound (inclusive). For discrete samplers, setting a reasonable maximum is particularly
+     *   important for Pareto distributions, as they can generate extreme outliers.
+     *
+     * @param shuffled
+     *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes
+     *   the values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to
+     *   value.
+     */
+    final case class ScaleShapeSettings[Value: Sampled](
+        scale: Value,
+        shape: Double,
+        max: Option[Value] = None,
+        shuffled: Option[Boolean] = None)
+        extends ParetoSettings[Value]
+
+    /**
+     * Pareto distribution parameters specified by minimum value and 95th percentile.
+     *
+     * Provides a more intuitive way to configure a Pareto distribution.
+     *
+     * @param min
+     *   The minimum possible value.
+     *
+     * @param p95
+     *   The 95th percentile value (95% of values will be below this)
+     *
+     * @param max
+     *   Optional maximum value bound (inclusive). If not specified, the distribution can generate values much larger
+     *   than p95 (the remaining 5% of the distribution). For discrete samplers, setting this prevents occasional
+     *   extreme values.
+     *
+     * @param shuffled
+     *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes
+     *   the values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to
+     *   value.
+     */
+    final case class MinP95Settings[Value: Sampled](
+        min: Value,
+        p95: Value,
+        max: Option[Value] = None,
+        shuffled: Option[Boolean] = None)
+        extends ParetoSettings[Value]
+  }
+
+  /**
+   * Categorical distribution settings for sampling from a discrete set of values with specified probabilities.
+   *
+   * @param categories
+   *   A sequence of category settings, each with a value and an associated weight.
+   */
+  final case class CategoricalSettings[Value: Sampled](categories: Seq[CategorySettings[Value]])
+      extends SamplerSettings[Value] {
+    override def shuffled: Option[Boolean] = None
+  }
+
+  /**
+   * Defines a single category with its value and relative weight for use in categorical sampling.
+   *
+   * @param value
+   *   The value associated with this category
+   * @param weight
+   *   The relative probability weight for this category. Weights do not need to sum to 1.0.
+   */
+  final case class CategorySettings[Value: Sampled](value: Value, weight: Double)
+
+  /**
+   * Composite sampler settings that combine multiple samplers with different weights.
+   *
+   * @param samplers
+   *   A sequence of weighted sampler settings, each with its own distribution and relative probability weight.
+   */
+  final case class CompositeSettings[Value: Sampled](samplers: Seq[WeightedSamplerSettings[Value]])
+      extends SamplerSettings[Value] {
+    override def shuffled: Option[Boolean] = None
+  }
+
+  /**
+   * Defines a sampler with its relative weight for use in composite sampling.
+   *
+   * @param sampler
+   *   The sampler settings to use
+   * @param weight
+   *   The relative weight determining how often this sampler is chosen from the composite. Higher weights increase the
+   *   likelihood of this sampler being used. Weights do not need to sum to 1.0.
+   */
+  final case class WeightedSamplerSettings[Value: Sampled](sampler: SamplerSettings[Value], weight: Double)
+}
+
+/**
+ * Represents the shape of a distribution used for sampling from a provided min-max range.
+ */
+sealed trait DistributionShape {
+
+  /**
+   * Whether to apply shuffling to the distribution output. Shuffling is most meaningful for distributions where values
+   * have different probabilities. Shuffling is only supported for discrete distributions.
+   */
+  def shuffled: Option[Boolean]
+}
+
+object DistributionShape {
+
+  /**
+   * Uniform distribution where all values within the specified range have equal probability.
+   */
+  case object Uniform extends DistributionShape {
+    override def shuffled: Option[Boolean] = None
+  }
+
+  /**
+   * Zipf distribution for modeling power-law relationships.
+   *
+   * @param exponent
+   *   Controls the "steepness" of the distribution. Higher values create more skewed distributions where the
+   *   highest-ranked items occur much more frequently than others. Typical values range from 1.0 to 3.0, with 1.0 being
+   *   classic Zipf's law.
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to rank
+   *   (i.e., the smallest values shouldn't necessarily be the most common). Default is false.
+   */
+  final case class Zipf(exponent: Double, shuffled: Option[Boolean] = None) extends DistributionShape
+
+  /**
+   * Exponential distribution where the probability of an event decreases exponentially with time.
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to value.
+   */
+  final case class Exponential(shuffled: Option[Boolean] = None) extends DistributionShape
+
+  /**
+   * Weibull distribution, versatile for modeling values with different variability patterns.
+   *
+   * @param shape
+   *   The shape parameter (k) that determines the distribution's behavior:
+   *   - shape < 1: decreasing rate (many smaller values, with long tails)
+   *   - shape = 1: constant rate (equivalent to exponential distribution)
+   *   - shape > 1: increasing rate (samples cluster around the characteristic value)
+   *   - shape ≈ 3.5: approximates normal distribution (symmetric around the mean)
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to value.
+   */
+  final case class Weibull(shape: Double, shuffled: Option[Boolean] = None) extends DistributionShape
+
+  /**
+   * Gamma distribution, good for modeling the sum of exponential random variables.
+   *
+   * @param shape
+   *   The shape parameter (k) that controls the basic form of the distribution.
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to value.
+   */
+  final case class Gamma(shape: Double, shuffled: Option[Boolean] = None) extends DistributionShape
+
+  /**
+   * Log-normal distribution, useful for modeling values with positive skew.
+   *
+   * @param shape
+   *   The shape parameter (σ), which is the standard deviation in logarithmic space. Higher values create more
+   *   dispersed distributions with heavier tails.
+   *   - shape ≈ 0.1: very tight distribution close to the median
+   *   - shape ≈ 0.5: moderate variation around the median
+   *   - shape ≈ 1.0: substantial variation with many extreme values
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to value.
+   */
+  final case class LogNormal(shape: Double, shuffled: Option[Boolean] = None) extends DistributionShape
+
+  /**
+   * Pareto distribution, useful for modeling heavy-tailed samples following power-law behavior ("80/20 rule").
+   *
+   * @param shape
+   *   The shape parameter (α), controlling the tail heaviness (Pareto index):
+   *   - shape ≈ 1.1-1.5: Extremely heavy tail (many extreme outliers)
+   *   - shape ≈ 1.5-2.0: Heavy tail (classic 80/20 rule)
+   *   - shape > 2.0: Moderate tail with fewer extreme outliers
+   *   - Must be greater than 1 for the distribution to have a finite mean.
+   *
+   * @param shuffled
+   *   Whether to apply shuffling to the distribution. Shuffling preserves the frequency distribution but randomizes the
+   *   values, creating a more realistic distribution for scenarios where frequency shouldn't be directly tied to value.
+   */
+  final case class Pareto(shape: Double, shuffled: Option[Boolean] = None) extends DistributionShape
+}

--- a/src/main/scala/akka/projection/testing/simulation/Units.scala
+++ b/src/main/scala/akka/projection/testing/simulation/Units.scala
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import java.text.DecimalFormat
+
+import scala.concurrent.duration._
+import scala.util.matching.Regex
+
+final class Slice private (val value: Int) extends AnyVal {
+  override def toString: String = s"Slice($value)"
+}
+
+object Slice {
+  val MinValue = 0
+  val MaxValue = 1023
+
+  def apply(value: Int): Slice = {
+    require(
+      value >= Slice.MinValue && value <= Slice.MaxValue,
+      s"Slice value must be between ${Slice.MinValue} and ${Slice.MaxValue} (inclusive), got: $value")
+    new Slice(value)
+  }
+
+  def parse(s: String): Slice = {
+    try {
+      val intValue = s.trim.toInt
+      apply(intValue)
+    } catch {
+      case e: NumberFormatException =>
+        throw new IllegalArgumentException(s"Cannot parse [$s] as an Int for Slice.", e)
+      case e: IllegalArgumentException =>
+        throw new IllegalArgumentException(s"Invalid value for Slice: $s. ${e.getMessage}", e)
+    }
+  }
+
+  implicit val ordering: Ordering[Slice] = Ordering.by(_.value)
+
+  implicit val sliceRangeable: Rangeable[Slice] = new Rangeable[Slice] {
+    def parse(s: String): Slice = Slice.parse(s)
+    def format(slice: Slice): String = slice.value.toString
+  }
+}
+
+sealed abstract class CountUnit(val symbol: String, val factor: Long) {
+  override def toString: String = symbol
+}
+
+object CountUnit {
+  case object One extends CountUnit("", 1)
+  case object Kilo extends CountUnit("k", 1_000)
+  case object Mega extends CountUnit("M", 1_000_000)
+  case object Giga extends CountUnit("G", 1_000_000_000)
+
+  val values: Seq[CountUnit] = Seq(One, Kilo, Mega, Giga)
+
+  private val unitsMap: Map[String, CountUnit] =
+    values.map(unit => unit.symbol -> unit).toMap
+
+  def parse(symbol: String): CountUnit =
+    unitsMap.getOrElse(symbol, One)
+}
+
+final class Count private (val value: Double, val unit: CountUnit) {
+  def toInt: Int = (value * unit.factor).toInt
+  def toLong: Long = (value * unit.factor).toLong
+
+  def to(targetUnit: CountUnit): Count = {
+    val newValue = value * unit.factor / targetUnit.factor
+    Count(newValue, targetUnit)
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: Count => this.toLong == that.toLong
+    case _           => false
+  }
+
+  override def hashCode(): Int = toLong.hashCode()
+
+  override def toString: String = {
+    val formattedValue = new DecimalFormat("#.######").format(value)
+    s"$formattedValue$unit"
+  }
+}
+
+object Count {
+  def apply(value: Double, unit: CountUnit = CountUnit.One): Count =
+    new Count(value, unit)
+
+  def apply(value: Int): Count = Count(value.toDouble)
+
+  def parse(s: String): Count = {
+    val pattern = """^\s*(\d+(?:\.\d+)?)\s*([kMG]?)\s*$""".r
+    s match {
+      case pattern(valueStr, suffix) =>
+        val value = valueStr.toDouble
+        val unit = CountUnit.parse(suffix)
+        new Count(value, unit)
+      case _ =>
+        throw new IllegalArgumentException(s"Not parseable as a count: $s")
+    }
+  }
+}
+
+final class RatePerUnit(val value: Double, val unit: TimeUnit) {
+
+  def toPerUnit(targetUnit: TimeUnit): RatePerUnit = {
+    if (targetUnit == unit) this
+    else {
+      val sourceNanos = 1.second.toNanos / unit.toNanos(1)
+      val targetNanos = 1.second.toNanos / targetUnit.toNanos(1)
+      val conversionFactor = sourceNanos / targetNanos
+      RatePerUnit(value * conversionFactor, targetUnit)
+    }
+  }
+
+  def toRate: Rate = Rate(toPerUnit(SECONDS).value)
+
+  override def equals(other: Any): Boolean = other match {
+    case that: RatePerUnit =>
+      val thisRate = this.toPerUnit(SECONDS).value
+      val thatRate = that.toPerUnit(SECONDS).value
+      math.abs(thisRate - thatRate) < 0.000001 // handle floating point precision issues
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    val normalizedRate = toPerUnit(SECONDS).value
+    normalizedRate.hashCode()
+  }
+
+  override def toString: String = {
+    val formattedValue = new DecimalFormat("#.######").format(value)
+    val formattedUnit = unit match {
+      case NANOSECONDS  => "ns"
+      case MICROSECONDS => "μs"
+      case MILLISECONDS => "ms"
+      case SECONDS      => "s"
+      case MINUTES      => "min"
+      case HOURS        => "h"
+      case DAYS         => "d"
+    }
+    s"$formattedValue / $formattedUnit"
+  }
+}
+
+object RatePerUnit {
+  def apply(value: Double, unit: TimeUnit): RatePerUnit = new RatePerUnit(value, unit)
+
+  def parse(s: String): RatePerUnit = {
+    val parts = s.split('/')
+    if (parts.length != 2) throw new IllegalArgumentException("Frequency must be in the format 'value / unit'")
+    val value = parts(0).trim.toDouble
+    s"1 ${parts(1)}" match {
+      case Duration(_, unit) => RatePerUnit(value, unit)
+      case _                 => throw new IllegalArgumentException("Frequency must be in the format 'value / unit'")
+    }
+  }
+}
+
+sealed abstract class DataUnit(val prefix: String, val short: String, val base: Int, val exponent: Int) {
+  val bytes: Int = math.pow(base, exponent).toInt
+  override def toString: String = short + "B"
+}
+
+object DataUnit {
+  case object Bytes extends DataUnit("", "", 1024, 0)
+
+  case object Kilobytes extends DataUnit("kilo", "k", 1000, 1)
+  case object Megabytes extends DataUnit("mega", "M", 1000, 2)
+  case object Gigabytes extends DataUnit("giga", "G", 1000, 3)
+
+  case object Kibibytes extends DataUnit("kibi", "Ki", 1024, 1)
+  case object Mebibytes extends DataUnit("mebi", "Mi", 1024, 2)
+  case object Gibibytes extends DataUnit("gibi", "Gi", 1024, 3)
+
+  val values: Seq[DataUnit] = Seq(Bytes, Kilobytes, Megabytes, Gigabytes, Kibibytes, Mebibytes, Gibibytes)
+
+  private val unitsMap: Map[String, DataUnit] = {
+    val units = Map.newBuilder[String, DataUnit]
+    for (unit <- values) {
+      units += (unit.prefix + "byte" -> unit)
+      units += (unit.prefix + "bytes" -> unit)
+      units += (unit.short -> unit)
+      units += (unit.short + "B" -> unit)
+    }
+    units.result()
+  }
+
+  def parse(unit: String): DataUnit =
+    unitsMap.getOrElse(unit, throw new IllegalArgumentException("Not parseable as a data unit"))
+}
+
+final class DataSize(val value: Double, val unit: DataUnit) {
+  def toBytes: Int = (value * unit.bytes).toInt
+
+  def to(targetUnit: DataUnit): DataSize = {
+    val newValue = value * unit.bytes / targetUnit.bytes
+    DataSize(newValue, targetUnit)
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: DataSize => this.toBytes == that.toBytes
+    case _              => false
+  }
+
+  override def hashCode(): Int = {
+    toBytes.hashCode()
+  }
+
+  override def toString: String = {
+    val formattedValue = new DecimalFormat("#.######").format(value)
+    s"$formattedValue $unit"
+  }
+}
+
+object DataSize {
+  private val SizePattern: Regex = """^\s*(\d+(?:\.\d+)?)\s*([a-zA-Z]*)?\s*$""".r
+
+  def apply(value: Double, unit: DataUnit): DataSize = new DataSize(value, unit)
+
+  def apply(value: Int): DataSize = DataSize(value.toDouble, DataUnit.Bytes)
+
+  def parse(size: String): DataSize = {
+    size match {
+      case SizePattern(valueStr, unitStr) =>
+        val value = valueStr.toDouble
+        val unit = DataUnit.parse(Option(unitStr).getOrElse(""))
+        new DataSize(value, unit)
+      case _ => throw new IllegalArgumentException(s"Not parseable as a data size: $size")
+    }
+  }
+}
+
+trait Rangeable[A] {
+  def parse(s: String): A
+  def format(a: A): String
+}
+
+object Rangeable {
+  implicit val intRangeable: Rangeable[Int] = new Rangeable[Int] {
+    def parse(s: String): Int = s.toInt
+    def format(i: Int): String = i.toString
+  }
+}
+
+sealed trait Range[+A] {
+  def min: Option[A]
+  def max: Option[A]
+  def contains[B >: A](value: B)(implicit ordering: Ordering[B]): Boolean
+}
+
+object Range {
+  case object Default extends Range[Nothing] {
+    override def min: Option[Nothing] = None
+    override def max: Option[Nothing] = None
+    override def contains[B >: Nothing](value: B)(implicit ordering: Ordering[B]): Boolean = true
+    override def toString: String = "*"
+  }
+
+  final case class Inclusive[A](start: A, end: A)(implicit rangeable: Rangeable[A]) extends Range[A] {
+    override def min: Option[A] = Some(start)
+    override def max: Option[A] = Some(end)
+    override def contains[B >: A](value: B)(implicit ordering: Ordering[B]): Boolean =
+      ordering.gteq(value, start) && ordering.lteq(value, end)
+    override def toString: String = s"${rangeable.format(start)}-${rangeable.format(end)}"
+  }
+
+  final case class Single[A](value: A)(implicit rangeable: Rangeable[A]) extends Range[A] {
+    override def min: Option[A] = Some(value)
+    override def max: Option[A] = Some(value)
+    override def contains[B >: A](value: B)(implicit ordering: Ordering[B]): Boolean =
+      ordering.equiv(this.value, value)
+    override def toString: String = rangeable.format(value)
+  }
+
+  final case class Multi[A: Rangeable: Ordering](ranges: Seq[Range[A]]) extends Range[A] {
+    override def min: Option[A] = ranges.flatMap(_.min).minOption
+    override def max: Option[A] = ranges.flatMap(_.max).maxOption
+    override def contains[B >: A](value: B)(implicit ordering: Ordering[B]): Boolean = ranges.exists(_.contains(value))
+    override def toString: String = ranges.mkString(",")
+  }
+
+  def parse[A: Ordering](s: String)(implicit rangeable: Rangeable[A]): Range[A] = {
+    s match {
+      case "*" => Range.Default
+      case values =>
+        val rangeStrings = values.split(',').map(_.trim)
+        val ranges = rangeStrings.map {
+          case "*" => throw new IllegalArgumentException("Multi range cannot contain Default (*)")
+          case range =>
+            range.split('-') match {
+              case Array(start, end) => Range.Inclusive(rangeable.parse(start.trim), rangeable.parse(end.trim))
+              case Array(single)     => Range.Single(rangeable.parse(single.trim))
+              case _                 => throw new IllegalArgumentException(s"Cannot parse [$s] as a range")
+            }
+        }
+        if (ranges.length == 1) ranges.head else Range.Multi(ranges.toSeq)
+    }
+  }
+
+  def ordering[A](implicit ordering: Ordering[A]): Ordering[Range[A]] =
+    new Ordering[Range[A]] {
+      def compare(x: Range[A], y: Range[A]): Int = {
+        (x.min, y.min) match {
+          case (None, None)       => 0
+          case (None, _)          => 1 // default last
+          case (_, None)          => -1 // default last
+          case (Some(a), Some(b)) => ordering.compare(a, b)
+        }
+      }
+    }
+}
+
+final class RangeMap[A: Rangeable: Ordering, B](val ranges: Seq[(Range[A], B)]) extends Function[A, B] {
+  private val orderedRanges = ranges.sortBy(_._1)(Range.ordering)
+
+  def get(key: A): Option[B] =
+    orderedRanges.collectFirst { case (range, value) if range.contains(key) => value }
+
+  def apply(key: A): B =
+    get(key).getOrElse(throw new IllegalArgumentException(s"No range defined for [$key]"))
+
+  def mapValues[C](f: B => C): RangeMap[A, C] =
+    new RangeMap(ranges.map { case (range, value) => (range, f(value)) })
+
+  override def equals(other: Any): Boolean = other match {
+    case that: RangeMap[_, _] =>
+      if (this.ranges.size != that.ranges.size) false
+      else {
+        this.orderedRanges.zip(that.orderedRanges).forall { case ((range1, value1), (range2, value2)) =>
+          range1 == range2 && value1 == value2
+        }
+      }
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    orderedRanges
+      .map { case (range, value) =>
+        41 * range.hashCode() + value.hashCode()
+      }
+      .foldLeft(0)(_ * 41 + _)
+  }
+
+  override def toString: String = {
+    orderedRanges.map { case (range, value) => s"\"${range.toString}\" -> $value" }.mkString("RangeMap(", ", ", ")")
+  }
+}
+
+object RangeMap {
+  def apply[A: Rangeable: Ordering, B](mappings: (Range[A], B)*): RangeMap[A, B] =
+    new RangeMap(mappings)
+
+  def fromStrings[A: Rangeable: Ordering, B](mappings: (String, B)*): RangeMap[A, B] =
+    new RangeMap(mappings.map { case (rangeStr, value) => (Range.parse[A](rangeStr), value) })
+}

--- a/src/test/scala/akka/projection/testing/IntegrationSpec.scala
+++ b/src/test/scala/akka/projection/testing/IntegrationSpec.scala
@@ -53,9 +53,9 @@ class IntegrationSpec
       systems += Main.startNode(2552, 8052, 9002, 8552, config).toClassic
       validateAllMembersUp(8552, 2)
 
-      val test = RunTest("", 100, 1, 1, 100, 10000)
+      val test = RunTest(None, 100, 1, 1, 100, 10000)
       val response = Unmarshal(Http().singleRequest(Post("http://127.0.0.1:8051/test", test)).futureValue.entity)
-        .to[Response]
+        .to[RunTestResponse]
         .futureValue
 
       eventually {

--- a/src/test/scala/akka/projection/testing/SimulationIntegrationSpec.scala
+++ b/src/test/scala/akka/projection/testing/SimulationIntegrationSpec.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing
+
+import scala.concurrent.ExecutionContextExecutor
+import scala.concurrent.duration._
+import scala.util.Try
+
+import akka.actor.ActorSystem
+import akka.actor.typed.scaladsl.adapter._
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.client.RequestBuilding.Post
+import akka.http.scaladsl.model.ContentTypes
+import akka.http.scaladsl.model.HttpEntity
+import akka.http.scaladsl.model.HttpRequest
+import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.unmarshalling._
+import akka.management.cluster.ClusterHttpManagementJsonProtocol
+import akka.management.cluster.ClusterMembers
+import akka.projection.testing.TestRoutes._
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.Eventually
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.time.Milliseconds
+import org.scalatest.time.Seconds
+import org.scalatest.time.Span
+import org.scalatest.wordspec.AnyWordSpec
+import spray.json._
+
+class SimulationIntegrationSpec
+    extends AnyWordSpec
+    with Eventually
+    with BeforeAndAfterAll
+    with ScalaFutures
+    with ClusterHttpManagementJsonProtocol
+    with Matchers {
+
+  override implicit val patienceConfig: PatienceConfig =
+    PatienceConfig(timeout = Span(120, Seconds), interval = Span(500, Milliseconds))
+  implicit val testSystem: ActorSystem = ActorSystem()
+  implicit val ec: ExecutionContextExecutor = testSystem.dispatcher
+  private var systems: Set[ActorSystem] = Set(testSystem)
+
+  "End to end test" should {
+    "run simulation" in {
+      val configResource = sys.props.getOrElse("test.config", "local")
+      val config = ConfigFactory.load(configResource)
+      systems += Main.startNode(2551, 8051, 9001, 8551, config).toClassic
+      validateAllMembersUp(8551, 1)
+      systems += Main.startNode(2552, 8052, 9002, 8552, config).toClassic
+      validateAllMembersUp(8552, 2)
+
+      val simulation = """
+        {
+          "simulation": {
+            "stages": [
+              {
+                "duration": "3s",
+                "generators": [
+                  {
+                    "entityId": {
+                      "entity": {
+                        "count": 100
+                      }
+                    },
+                    "activity": {
+                      "frequency": "10/s",
+                      "duration": "1s",
+                      "event": {
+                        "frequency": "10/s",
+                        "dataSize": "100B"
+                      }
+                    },
+                    "random": {
+                      "seed": 123456789
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      """
+
+      val run = simulation.parseJson.convertTo[RunSimulation]
+      run.simulation.stages.size shouldBe 1
+
+      val entity = HttpEntity(ContentTypes.`application/json`, simulation)
+
+      val response =
+        Unmarshal(
+          Http()
+            .singleRequest(Post("http://127.0.0.1:8051/simulation/run", entity))
+            .futureValue
+            .entity)
+          .to[RunSimulationResponse]
+          .futureValue
+
+      eventually {
+        val result = Unmarshal(
+          Http()
+            .singleRequest(HttpRequest(uri = s"http://127.0.0.1:8051/simulation/status/${response.runId}"))
+            .futureValue
+            .entity).to[String].futureValue
+        println("got result: " + result)
+        result shouldEqual "pass"
+      }
+    }
+  }
+
+  def validateAllMembersUp(port: Int, nr: Int): Unit = {
+    eventually {
+      val members = Http()
+        .singleRequest(HttpRequest(uri = s"http://127.0.0.1:$port/cluster/members"))
+        .flatMap { response =>
+          response.status match {
+            case StatusCodes.OK =>
+              Unmarshal(response).to[ClusterMembers]
+            case other =>
+              throw new RuntimeException(
+                s"Unexpected status code: $other with body ${response.entity.toStrict(100.millis).futureValue}")
+          }
+        }
+        .futureValue
+      members.members.size shouldEqual nr
+      members.members.map(_.status.toLowerCase()) shouldEqual Set("up")
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    systems.foreach { system =>
+      Try(TestKit.shutdownActorSystem(system))
+    }
+  }
+}

--- a/src/test/scala/akka/projection/testing/simulation/SimpleAnalysis.scala
+++ b/src/test/scala/akka/projection/testing/simulation/SimpleAnalysis.scala
@@ -1,0 +1,543 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.collection.immutable.IntMap
+import scala.collection.mutable
+import scala.concurrent.duration._
+import scala.io.Source
+
+import spray.json._
+
+/**
+ * sbt "Test/runMain akka.projection.testing.simulation.SimpleAnalysis /path/to/simulation/run.json"
+ */
+object SimpleAnalysis {
+
+  final case class Stats(activities: Int, events: Int, data: Long) {
+    def +(that: Stats): Stats =
+      Stats(this.activities + that.activities, this.events + that.events, this.data + that.data)
+  }
+
+  object Stats {
+    val empty: Stats = Stats(0, 0, 0L)
+  }
+
+  final case class RateStats(min: Double, max: Double, avg: Double, windows: Int) {
+    def combine(other: RateStats): RateStats = {
+      val totalWindows = this.windows + other.windows
+      val combinedAvg = (this.avg * this.windows + other.avg * other.windows) / totalWindows
+      RateStats(math.min(this.min, other.min), math.max(this.max, other.max), combinedAvg, totalWindows)
+    }
+  }
+
+  object RateStats {
+    def fromSingleWindow(rate: Double): RateStats = RateStats(rate, rate, rate, 1)
+    val empty: RateStats = RateStats(0.0, 0.0, 0.0, 0)
+  }
+
+  final case class WindowStats(start: FiniteDuration, stats: Stats, slices: IntMap[Stats])
+
+  object WindowStats {
+    val empty: WindowStats = WindowStats(Duration.Zero, Stats.empty, IntMap.empty)
+  }
+
+  final case class Summary(stats: Stats, windows: Seq[WindowStats])
+
+  object Summary {
+    val empty: Summary = Summary(Stats.empty, Seq.empty)
+  }
+
+  final class StatsBuilder {
+    private var activities = 0
+    private var events = 0
+    private var data = 0L
+
+    def +=(event: Event): Unit = {
+      if (event.seqNr == 1) activities += 1
+      events += 1
+      data += event.dataBytes
+    }
+
+    def build(): Stats = Stats(activities, events, data)
+  }
+
+  val NumWindows = 500
+  val ColumnWidth = 148
+
+  def analyse(settings: SimulationSettings): Unit = {
+    val generator = SimulationGenerator(settings)
+    val totalDuration = calculateTotalDuration(settings)
+    val windowDuration = totalDuration / NumWindows
+
+    println("=" * ColumnWidth)
+    println(s"SIMULATION ANALYSIS: ${settings.name.getOrElse("Unnamed")}")
+    println("=" * ColumnWidth)
+
+    println(f"Total simulation duration: ${formatDuration(totalDuration)}")
+    println(f"Window duration: ${formatDuration(windowDuration)}")
+    println(f"Number of windows: $NumWindows")
+    println(" ")
+    renderProgressHeader()
+
+    val summary = generator
+      .groupedEvents(windowDuration)
+      .zipWithIndex
+      .foldLeft(Summary.empty) { case (summary, (group, index)) =>
+        val window = analyseWindow(windowDuration * index, group)
+        val totalStats = summary.stats + window.stats
+        displayProgress(totalStats, window, index, NumWindows, windowDuration)
+        Summary(totalStats, summary.windows :+ window)
+      }
+
+    println()
+    renderSummary(settings, summary, totalDuration, windowDuration)
+  }
+
+  def analyseWindow(start: FiniteDuration, group: Seq[Event]): WindowStats = {
+    val stats = new StatsBuilder
+    val slices = mutable.Map.empty[Int, StatsBuilder]
+
+    group.foreach { event =>
+      stats += event
+      val slice = event.activity.entityId.slice.value
+      slices.getOrElseUpdate(slice, new StatsBuilder) += event
+    }
+
+    WindowStats(start, stats.build(), slices.view.mapValues(_.build()).to(IntMap))
+  }
+
+  def calculateTotalDuration(settings: SimulationSettings): FiniteDuration = {
+    settings.stages.foldLeft(Duration.Zero) { case (total, stage) =>
+      total + stage.delay.getOrElse(Duration.Zero) + stage.duration
+    }
+  }
+
+  def calculateSliceRates(summary: Summary, windowDuration: FiniteDuration): Map[Int, RateStats] = {
+    val windowSeconds = windowDuration.toNanos / 1_000_000_000.0
+    val sliceRates = mutable.Map.empty[Int, mutable.ArrayBuffer[Double]]
+
+    summary.windows.foreach { window =>
+      window.slices.foreach { case (slice, stats) =>
+        val eventRate = stats.events.toDouble / windowSeconds
+        if (eventRate > 0.0) {
+          sliceRates.getOrElseUpdate(slice, mutable.ArrayBuffer.empty) += eventRate
+        }
+      }
+    }
+
+    sliceRates.view.mapValues(calculateRateStats).toMap
+  }
+
+  def calculateProjectionRates(summary: Summary, windowDuration: FiniteDuration): Map[Int, RateStats] = {
+    val windowSeconds = windowDuration.toNanos / 1_000_000_000.0
+    val projectionRates = mutable.Map.empty[Int, mutable.ArrayBuffer[Double]]
+
+    summary.windows.foreach { window =>
+      (0 until 8).foreach { projectionId =>
+        val startSlice = projectionId * 128
+        val endSlice = startSlice + 127
+        val projectionStats = window.slices
+          .filter { case (slice, _) =>
+            slice >= startSlice && slice <= endSlice
+          }
+          .values
+          .foldLeft(Stats.empty)(_ + _)
+
+        val eventRate = projectionStats.events.toDouble / windowSeconds
+        if (eventRate > 0.0) {
+          projectionRates.getOrElseUpdate(projectionId, mutable.ArrayBuffer.empty) += eventRate
+        }
+      }
+    }
+
+    projectionRates.view.mapValues(calculateRateStats).toMap
+  }
+
+  def calculateRateStats(rates: mutable.ArrayBuffer[Double]): RateStats = {
+    if (rates.isEmpty) return RateStats.empty
+
+    RateStats(rates.min, rates.max, rates.sum / rates.length, rates.length)
+  }
+
+  def renderProgressHeader(): Unit = {
+    println {
+      f"${"progress"}%24s " +
+      f"${"#"}%6s " +
+      f"${"time"}%12s " +
+      f"${"activities/s"}%15s " +
+      f"${"events/s"}%15s " +
+      f"${"activities"}%15s " +
+      f"${"events"}%15s " +
+      f"${"bytes"}%18s"
+    }
+    println("-" * ColumnWidth)
+  }
+
+  def displayProgress(
+      totals: Stats,
+      window: WindowStats,
+      windowIndex: Int,
+      numWindows: Int,
+      windowDuration: FiniteDuration): Unit = {
+    val progress = (windowIndex + 1).toDouble / numWindows * 100
+    val barWidth = 15
+    val filled = (progress / 100.0 * barWidth).toInt
+    val progressBar = "█" * filled + "░" * (barWidth - filled)
+    val windowSeconds = windowDuration.toNanos / 1_000_000_000.0
+    print {
+      f"\r$progressBar ${progress}%7.1f%% " +
+      f"${windowIndex + 1}%6d " +
+      f"${formatDuration(window.start)}%12s " +
+      f"${window.stats.activities / windowSeconds}%,13.1f/s " +
+      f"${window.stats.events / windowSeconds}%,13.1f/s " +
+      f"${totals.activities}%,15d " +
+      f"${totals.events}%,15d " +
+      f"${totals.data}%,18d"
+    }
+    System.out.flush()
+  }
+
+  def renderSummary(
+      settings: SimulationSettings,
+      summary: Summary,
+      totalDuration: FiniteDuration,
+      windowDuration: FiniteDuration): Unit = {
+    val stats = summary.stats
+    val avgEventsPerActivity = if (stats.activities > 0) stats.events.toDouble / stats.activities else 0.0
+    val avgActivitiesPerSec = stats.activities.toDouble / totalDuration.toNanos * 1_000_000_000.0
+    val avgEventsPerSec = stats.events.toDouble / totalDuration.toNanos * 1_000_000_000.0
+
+    println(" ")
+    println("=" * 120)
+    println(s"Simulation: ${settings.name.getOrElse("unnamed")}")
+    println("=" * 120)
+
+    settings.description.foreach { desc =>
+      println(" ")
+      println(s"Description: $desc")
+    }
+
+    println(" ")
+    println("SUMMARY")
+    println("-" * ColumnWidth)
+    println(f"Total duration: ${formatDuration(totalDuration)}")
+    println(f"Total activities: ${stats.activities}%,d")
+    println(f"Total events: ${stats.events}%,d")
+    println(f"Average events/activity: ${avgEventsPerActivity}%.2f")
+    println(f"Average activity rate: ${avgActivitiesPerSec}%.2f activities/s")
+    println(f"Average event rate: ${avgEventsPerSec}%.2f events/s")
+    println(f"Total data volume: ${formatBytes(stats.data)}")
+
+    renderPatterns(summary, windowDuration)
+    renderProjections(summary, windowDuration)
+    renderSlices(summary, windowDuration)
+
+    println(" ")
+  }
+
+  def renderPatterns(summary: Summary, windowDuration: FiniteDuration): Unit = {
+    println(" ")
+    println("PATTERNS")
+    println("-" * ColumnWidth)
+
+    val windowSeconds = windowDuration.toNanos / 1_000_000_000.0
+    val activityRates = summary.windows.map(w => w.stats.activities.toDouble / windowSeconds)
+    val eventRates = summary.windows.map(w => w.stats.events.toDouble / windowSeconds)
+
+    val maxActivityRate = activityRates.maxOption.getOrElse(0.0)
+    val maxEventRate = eventRates.maxOption.getOrElse(0.0)
+
+    println(f"Peak activity rate: ${maxActivityRate}%.2f activities/s")
+    println(f"Peak event rate: ${maxEventRate}%.2f events/s")
+    println(" ")
+
+    println {
+      f"${"#"}%4s " +
+      f"${"Time"}%8s " +
+      f"${"Activities/s"}%50s " +
+      f"${""}%12s " +
+      f"${"Events/s"}%50s " +
+      f"${""}%12s"
+    }
+    println("-" * ColumnWidth)
+
+    summary.windows.zipWithIndex.foreach { case (window, index) =>
+      val activityRate = window.stats.activities.toDouble / windowSeconds
+      val eventRate = window.stats.events.toDouble / windowSeconds
+
+      val activityBar = renderBar(activityRate, maxActivityRate, 40)
+      val eventBar = renderBar(eventRate, maxEventRate, 40)
+
+      println {
+        f"${index + 1}%4d " +
+        f"${formatDuration(window.start)}%8s " +
+        f"$activityBar%50s " +
+        f"${activityRate}%10.1f/s " +
+        f"$eventBar%50s " +
+        f"${eventRate}%10.1f/s"
+      }
+    }
+
+    println(" ")
+    println(
+      f"Activity rates - min: ${activityRates.minOption.getOrElse(0.0)}%.1f, " +
+        f"max: ${maxActivityRate}%.1f, " +
+        f"avg: ${activityRates.sum / activityRates.length}%.1f activities/s")
+    println(
+      f"Event rates - min: ${eventRates.minOption.getOrElse(0.0)}%.1f, " +
+        f"max: ${maxEventRate}%.1f, " +
+        f"avg: ${eventRates.sum / eventRates.length}%.1f events/s")
+  }
+
+  def renderBar(value: Double, maxValue: Double, width: Int): String = {
+    if (maxValue == 0.0) return " " * width
+
+    val normalizedValue = value / maxValue
+    val filledWidth = (normalizedValue * width).toInt
+    val remainder = (normalizedValue * width) - filledWidth
+
+    val fullChar = "█"
+    val partialChars = Array(" ", "▏", "▎", "▍", "▌", "▋", "▊", "▉")
+    val partialChar = partialChars((remainder * 8).toInt)
+
+    val bar = fullChar * filledWidth + (if (filledWidth < width && remainder > 0) partialChar else "")
+    val padding = " " * (width - bar.length)
+
+    bar + padding
+  }
+
+  def renderProjections(summary: Summary, windowDuration: FiniteDuration): Unit = {
+    println(" ")
+    println("PROJECTIONS")
+    println("-" * ColumnWidth)
+
+    val sliceStats = mutable.Map.empty[Int, Stats]
+    summary.windows.foreach { window =>
+      window.slices.foreach { case (slice, stats) =>
+        sliceStats.updateWith(slice) {
+          case Some(existing) => Some(existing + stats)
+          case None           => Some(stats)
+        }
+      }
+    }
+
+    val projectionEventRates = calculateProjectionRates(summary, windowDuration)
+
+    // Analyze 8 projection instances (128 slices each)
+    val instanceLoads = (0 until 8).map { instance =>
+      val startSlice = instance * 128
+      val endSlice = startSlice + 127
+      val instanceSliceStats = sliceStats.filter { case (slice, _) => slice >= startSlice && slice <= endSlice }
+      val instanceStats = instanceSliceStats.values.foldLeft(Stats.empty)(_ + _)
+
+      val sliceEventCounts = (startSlice to endSlice).map { slice =>
+        sliceStats.get(slice).map(_.events).getOrElse(0)
+      }
+      val minEvents = if (sliceEventCounts.nonEmpty) sliceEventCounts.min else 0
+      val maxEvents = if (sliceEventCounts.nonEmpty) sliceEventCounts.max else 0
+      val avgEvents = if (sliceEventCounts.nonEmpty) sliceEventCounts.sum.toDouble / sliceEventCounts.length else 0.0
+
+      val eventRateStats = projectionEventRates.getOrElse(instance, RateStats.empty)
+
+      (instance, startSlice, endSlice, instanceStats, minEvents, maxEvents, avgEvents, eventRateStats)
+    }
+
+    val totalEvents = sliceStats.values.map(_.events).sum
+
+    println(" ")
+    println {
+      f"${"#"}%3s " +
+      f"${"Slices"}%11s " +
+      f"${"Load %"}%8s " +
+      f"${"Activities"}%12s " +
+      f"${"Events"}%12s " +
+      f"${"Min/second"}%12s " +
+      f"${"Max/second"}%12s " +
+      f"${"Avg/second"}%12s " +
+      f"${"Min/slice"}%12s " +
+      f"${"Max/slice"}%12s " +
+      f"${"Avg/slice"}%12s"
+    }
+    println("-" * ColumnWidth)
+
+    instanceLoads.foreach { case (instance, start, end, stats, minEvents, maxEvents, avgEvents, eventRateStats) =>
+      val percentage = if (totalEvents > 0) (stats.events.toDouble / totalEvents) * 100 else 0.0
+      println {
+        f"$instance%3d " +
+        f"$start%4s - $end%4s " +
+        f"${percentage}%7.2f%% " +
+        f"${stats.activities}%12d " +
+        f"${stats.events}%12d " +
+        f"${eventRateStats.min}%10.1f/s " +
+        f"${eventRateStats.max}%10.1f/s " +
+        f"${eventRateStats.avg}%10.1f/s " +
+        f"${minEvents}%12d " +
+        f"${maxEvents}%12d " +
+        f"${avgEvents}%12.1f"
+      }
+    }
+  }
+
+  def renderSlices(summary: Summary, windowDuration: FiniteDuration): Unit = {
+    println(" ")
+    println("SLICES (top 10)")
+    println("-" * ColumnWidth)
+
+    val sliceStats = mutable.Map.empty[Int, Stats]
+    summary.windows.foreach { window =>
+      window.slices.foreach { case (slice, stats) =>
+        sliceStats.updateWith(slice) {
+          case Some(existing) => Some(existing + stats)
+          case None           => Some(stats)
+        }
+      }
+    }
+
+    val sortedSlices = sliceStats.toSeq.sortBy(-_._2.events).take(10)
+    val totalEvents = sliceStats.values.map(_.events).sum
+
+    val sliceEventRates = calculateSliceRates(summary, windowDuration)
+
+    println(" ")
+    println {
+      f"${"Slice"}%5s " +
+      f"${"Total %"}%8s " +
+      f"${"Activities"}%12s " +
+      f"${"Events"}%12s " +
+      f"${"Data"}%12s " +
+      f"${"Min/second"}%12s " +
+      f"${"Max/second"}%12s " +
+      f"${"Avg/second"}%12s"
+    }
+    println("-" * ColumnWidth)
+
+    sortedSlices.foreach { case (slice, stats) =>
+      val percentage = if (totalEvents > 0) (stats.events.toDouble / totalEvents) * 100 else 0.0
+      val eventRateStats = sliceEventRates.getOrElse(slice, RateStats.empty)
+      println {
+        f"${slice}%5d " +
+        f"${percentage}%7.2f%% " +
+        f"${stats.activities}%12d " +
+        f"${stats.events}%12d " +
+        f"${formatBytes(stats.data)}%12s " +
+        f"${eventRateStats.min}%10.1f/s " +
+        f"${eventRateStats.max}%10.1f/s " +
+        f"${eventRateStats.avg}%10.1f/s"
+      }
+    }
+
+    renderSliceDistribution(summary)
+  }
+
+  def calculateSliceVariance(sliceStats: Map[Int, Stats]): Double = {
+    if (sliceStats.isEmpty) return 0.0
+
+    val eventCounts = sliceStats.values.map(_.events.toDouble).toSeq
+    if (eventCounts.isEmpty) return 0.0
+
+    val mean = eventCounts.sum / eventCounts.length
+    if (mean == 0.0) return 0.0
+
+    val variance = eventCounts.map(x => math.pow(x - mean, 2)).sum / eventCounts.length
+    val stdDev = math.sqrt(variance)
+
+    // Return coefficient of variation (CV)
+    stdDev / mean
+  }
+
+  def renderSliceDistribution(summary: Summary): Unit = {
+    val sliceStats = mutable.Map.empty[Int, Stats]
+    summary.windows.foreach { window =>
+      window.slices.foreach { case (slice, stats) =>
+        sliceStats.updateWith(slice) {
+          case Some(existing) => Some(existing + stats)
+          case None           => Some(stats)
+        }
+      }
+    }
+
+    val varianceCoeff = calculateSliceVariance(sliceStats.toMap)
+
+    println(" ")
+    println("SLICE DISTRIBUTION")
+    println("-" * ColumnWidth)
+    println(f"Coefficient of variation: ${varianceCoeff * 100}%.1f%%")
+    println(" ")
+
+    // Group slices by projection instance (8 instances, 128 slices each)
+    val instanceDistributions = (0 until 8).map { instance =>
+      val startSlice = instance * 128
+      val endSlice = startSlice + 127
+
+      val sliceCounts = (startSlice to endSlice).map { slice =>
+        sliceStats.get(slice).map(_.events).getOrElse(0).toDouble
+      }
+
+      (instance, startSlice, endSlice, sliceCounts)
+    }
+
+    val maxEvents = instanceDistributions.flatMap(_._4).maxOption.getOrElse(1.0)
+
+    def getBarChar(value: Double, maxValue: Double): Char = {
+      if (maxValue == 0.0) return ' '
+      val intensity = value / maxValue
+      if (intensity == 0.0) ' '
+      else if (intensity <= 0.125) '▁'
+      else if (intensity <= 0.25) '▂'
+      else if (intensity <= 0.375) '▃'
+      else if (intensity <= 0.5) '▄'
+      else if (intensity <= 0.625) '▅'
+      else if (intensity <= 0.75) '▆'
+      else if (intensity <= 0.875) '▇'
+      else '█'
+    }
+
+    println(f"${"#"}%3s ${"Slices"}%11s ${"Event distribution (128 slices, one character per slice)"}%132s")
+    println("-" * ColumnWidth)
+
+    instanceDistributions.foreach { case (instance, start, end, sliceCounts) =>
+      val distributionBar = sliceCounts.map(count => getBarChar(count, maxEvents)).mkString("")
+
+      println(f"$instance%3d $start%4s - $end%4s    $distributionBar")
+    }
+  }
+
+  def formatDuration(duration: FiniteDuration): String = {
+    val seconds = duration.toNanos / 1_000_000_000.0
+    if (seconds < 60) f"${seconds}%.2fs"
+    else if (seconds < 3600) f"${seconds / 60}%.2fm"
+    else if (seconds < 86400) f"${seconds / 3600}%.2fh"
+    else f"${seconds / 86400}%.2fd"
+  }
+
+  def formatBytes(bytes: Long): String = {
+    val units = Array("B", "kB", "MB", "GB", "TB")
+    var value = bytes.toDouble
+    var unitIndex = 0
+    while (value >= 1024 && unitIndex < units.length - 1) {
+      value /= 1024
+      unitIndex += 1
+    }
+    f"${value}%.1f${units(unitIndex)}"
+  }
+
+  def run(runSimulationFile: String): Unit = {
+    import akka.projection.testing.TestRoutes._
+    val runJson = Source.fromFile(runSimulationFile).mkString
+    val settings = runJson.parseJson.convertTo[RunSimulation].simulation
+    analyse(settings)
+  }
+
+  def main(args: Array[String]): Unit = {
+    if (args.length < 1) {
+      println("Usage: SimpleAnalysis <simulation.json>")
+      sys.exit(1)
+    }
+
+    val runSimulationFile = args(0)
+    run(runSimulationFile)
+  }
+}

--- a/src/test/scala/akka/projection/testing/simulation/SimulationGeneratorSpec.scala
+++ b/src/test/scala/akka/projection/testing/simulation/SimulationGeneratorSpec.scala
@@ -1,0 +1,657 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.concurrent.duration._
+
+import akka.projection.testing.simulation.SimulationJsonFormat._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import spray.json._
+
+class SimulationGeneratorSpec extends AnyWordSpec with Matchers {
+
+  "SimulationGenerator" should {
+
+    "generate events for a simple single stage" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "duration": "10s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": { "count": "10k" }
+                  },
+                  "activity": {
+                    "frequency": "10/s",
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "10/s",
+                      "dataSize": "10B"
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+      val generator = SimulationGenerator(settings)
+
+      val events = generator.events().toSeq
+      val activities = events.groupBy(_.activity.id)
+
+      events.size shouldBe 1000 +- 300
+
+      events.foreach { event =>
+        event.activity.id.generator shouldBe 1
+        event.activity.id.stage shouldBe 1
+        event.activity.id.seqNr should (be >= 1 and be <= activities.size)
+        event.activity.entityId.entity should (be >= 1 and be <= 10000)
+        event.activity.entityId.slice.value should (be >= 0 and be <= 1023)
+        event.activity.start.value should (be >= 0.0 and be <= 10.0)
+        event.activity.duration.value shouldBe 1.0
+        event.time.value should (be >= 0.0 and be <= 10.0)
+        event.point.value should be <= event.activity.duration.value
+        event.dataBytes shouldBe 10
+      }
+
+      activities.size shouldBe 100 +- 30
+
+      activities.values.foreach { activityEvents =>
+        activityEvents.map(_.seqNr) shouldBe (1 to activityEvents.size)
+      }
+    }
+
+    "generate events for multiple stages" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "name": "Stage 1",
+              "duration": "10s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": 1
+                  },
+                  "activity": {
+                    "frequency": "1/s",
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "1/s",
+                      "dataSize": 1
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "name": "Stage 2",
+              "delay": "10s",
+              "duration": "10s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": 2
+                  },
+                  "activity": {
+                    "frequency": "1/s",
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "1/s",
+                      "dataSize": 2
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+       """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+      val generator = SimulationGenerator(settings)
+
+      val events = generator.events().toSeq
+
+      val stage1Events = events.filter(_.activity.id.stage == 1)
+      val stage2Events = events.filter(_.activity.id.stage == 2)
+
+      stage1Events.size should be >= 1
+      stage2Events.size should be >= 1
+
+      events.size shouldBe (stage1Events.size + stage2Events.size)
+
+      stage1Events.foreach { event =>
+        event.time.value should (be >= 0.0 and be < 10.0)
+        event.activity.entityId.entity shouldBe 1
+        event.dataBytes shouldBe 1
+      }
+
+      stage2Events.foreach { event =>
+        event.time.value should (be >= 20.0 and be < 30.0)
+        event.activity.entityId.entity shouldBe 2
+        event.dataBytes shouldBe 2
+      }
+    }
+
+    "generate events from multiple generators within a stage" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "duration": "10s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": 1
+                  },
+                  "activity": {
+                    "frequency": "1/s",
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "1/s",
+                      "dataSize": 1
+                    }
+                  }
+                },
+                {
+                  "entityId": {
+                    "entity": 2
+                  },
+                  "activity": {
+                    "frequency": "1/s",
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "1/s",
+                      "dataSize": 2
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+       """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+      val generator = SimulationGenerator(settings)
+
+      val events = generator.events().toSeq
+
+      val gen1Events = events.filter(_.activity.id.generator == 1)
+      val gen2Events = events.filter(_.activity.id.generator == 2)
+
+      gen1Events.size should be >= 1
+      gen2Events.size should be >= 1
+
+      events.size shouldBe (gen1Events.size + gen2Events.size)
+
+      gen1Events.foreach(_.dataBytes shouldBe 1)
+      gen2Events.foreach(_.dataBytes shouldBe 2)
+
+      // check events across generators are ordered by time
+      events.sliding(2).foreach {
+        case Seq(event1, event2) => event1.time.value should be <= event2.time.value
+        case _                   =>
+      }
+    }
+
+    "group events by time window" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "duration": "10s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": 1
+                  },
+                  "activity": {
+                    "frequency": "10/s",
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "10/s",
+                      "dataSize": 1
+                    }
+                  }
+                }
+              ]
+            }
+          ]
+        }
+       """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+      val generator = SimulationGenerator(settings)
+
+      val window = 200.millis
+      val groupedEvents = generator.groupedEvents(window).toSeq
+
+      // check all grouped events are the same as regularly generated events
+
+      groupedEvents.flatten shouldBe generator.events().toSeq
+
+      // check grouped events are within expected boundaries
+
+      val windowSeconds = Point(window).value
+      val boundaries = Iterator.unfold(0.0) { startBoundary =>
+        val endBoundary = startBoundary + windowSeconds
+        Some(((startBoundary, endBoundary), endBoundary))
+      }
+
+      groupedEvents.zip(boundaries).foreach { case (group, (startBoundary, endBoundary)) =>
+        group.foreach { event =>
+          event.time.value should (be >= startBoundary and be < endBoundary)
+        }
+      }
+    }
+
+    "generate deterministic events with a random seed" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "duration": "10s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": {
+                      "count": "1k"
+                    }
+                  },
+                  "activity": {
+                    "frequency": "10/s",
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "20/s",
+                      "dataSize": "10B"
+                    }
+                  },
+                  "random": {
+                    "seed": 12345
+                  }
+                }
+              ]
+            }
+          ]
+        }
+       """.parseJson
+
+      val settings1 = json.convertTo[SimulationSettings]
+      val generator1 = SimulationGenerator(settings1)
+      val events1 = generator1.events().toSeq
+
+      val settings2 = json.convertTo[SimulationSettings]
+      val generator2 = SimulationGenerator(settings2)
+      val events2 = generator2.events().toSeq
+
+      events1.size should be > 1000
+      events1 shouldBe events2
+    }
+
+    "generate events with Zipf distribution" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "duration": "10s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": {
+                      "distribution": "zipf",
+                      "min": 1,
+                      "max": 1000,
+                      "exponent": 1.5
+                    }
+                  },
+                  "activity": {
+                    "frequency": "100/s",
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "1/s",
+                      "dataSize": "10B"
+                    }
+                  },
+                  "random": {
+                    "seed": 12345
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+      val generator = SimulationGenerator(settings)
+
+      val events = generator.events().toSeq
+
+      // verify that entities are selected with a Zipf distribution
+
+      events.size should be > 1000
+
+      val entityCounts = events
+        .groupBy(_.activity.entityId.entity)
+        .view
+        .mapValues(_.size)
+        .toSeq
+        .sortBy(-_._2) // most frequent first
+
+      entityCounts.size should be > 100
+
+      // first entity should appear roughly 10^1.5 ≈ 32 times more than the 10th
+      val firstEntityCount = entityCounts.head._2
+      val tenthEntityCount = entityCounts(9)._2
+      val firstToTenthRatio = firstEntityCount.toDouble / tenthEntityCount.toDouble
+      firstToTenthRatio shouldBe 32.0 +- 2.0
+
+      // verify the decay curve by checking that each step has a significant drop in frequency
+      val countRatios = entityCounts
+        .take(10)
+        .map(_._2)
+        .sliding(2)
+        .map {
+          case Seq(a, b) => a.toDouble / b.toDouble
+          case _         => 0.0
+        }
+        .toSeq
+
+      val averageRatio = countRatios.sum / countRatios.size
+      averageRatio shouldBe 1.5 +- 0.1
+    }
+
+    "generate activity durations with log-normal distribution" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "duration": "10s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": 1
+                  },
+                  "activity": {
+                    "frequency": "100/s",
+                    "duration": {
+                      "distribution": "log-normal",
+                      "median": "1s",
+                      "p95": "5s",
+                      "min": "0.1s",
+                      "max": "10s"
+                    },
+                    "event": {
+                      "frequency": "10/s",
+                      "dataSize": "10B"
+                    }
+                  },
+                  "random": {
+                    "seed": 42
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+      val generator = SimulationGenerator(settings)
+
+      val events = generator.events().toSeq
+
+      // Log-normal distributions are:
+      // - right-skewed (mean > median)
+      // - most values cluster around the median, with a long tail
+
+      events.size should be > 10000
+
+      val activities = events.groupBy(_.activity.id)
+      val activityDurations = activities
+        .map { case (_, activityEvents) =>
+          activityEvents.head.activity.duration.value
+        }
+        .toSeq
+        .sorted
+
+      activityDurations.size should be > 1000
+      activityDurations.forall(_ >= 0.1) shouldBe true
+      activityDurations.forall(_ <= 10.0) shouldBe true
+
+      val median = if (activityDurations.size % 2 == 0) {
+        val mid = activityDurations.size / 2
+        (activityDurations(mid - 1) + activityDurations(mid)) / 2
+      } else {
+        activityDurations(activityDurations.size / 2)
+      }
+
+      val mean = activityDurations.sum / activityDurations.size
+
+      // check expected median at ~1s
+      median shouldBe 1.0 +- 0.05
+
+      // for log-normal, mean should always be greater than median
+      mean should be > median
+
+      // check the 95th percentile at ~5s
+      val p95Index = math.floor(activityDurations.size * 0.95).toInt
+      val p95 = activityDurations(p95Index)
+      p95 should be(5.0 +- 0.5)
+
+      // roughly 50% below median (1.0)
+      val below1Percentage = activityDurations.count(_ < 1.0).toDouble / activityDurations.size
+      below1Percentage shouldBe 0.5 +- 0.15
+
+      // verify the distribution is right-skewed
+      val countFrom1To2 = activityDurations.count(duration => duration >= 1.0 && duration < 2.0)
+      val countFrom2To5 = activityDurations.count(duration => duration >= 2.0 && duration < 5.0)
+      val countFrom5To10 = activityDurations.count(duration => duration >= 5.0 && duration <= 10.0)
+      countFrom1To2 should be > countFrom2To5
+      countFrom2To5 should be > countFrom5To10
+    }
+
+    "generate activities with linear rate function" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "duration": "20s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": 1
+                  },
+                  "activity": {
+                    "frequency": {
+                      "function": "linear",
+                      "initial": "1/s",
+                      "target": "10/s"
+                    },
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "1/s",
+                      "dataSize": "10B"
+                    }
+                  },
+                  "random": {
+                    "seed": 42
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+      val generator = SimulationGenerator(settings)
+
+      val events = generator.events().toSeq
+      val activities = events.map(_.activity).distinct
+
+      activities.size shouldBe 100 +- 5
+
+      // check activity density over time by dividing into 5 equal parts
+      val timeSegments = 5
+      val segmentDuration = 20.0 / timeSegments
+      val eventCountBySegment = (0 until timeSegments).map { i =>
+        val segmentStart = i * segmentDuration
+        val segmentEnd = segmentStart + segmentDuration
+        events.count(event => event.time.value >= segmentStart && event.time.value < segmentEnd)
+      }
+
+      // verify each subsequent segment has more events than the previous one
+      for (i <- 0 until timeSegments - 1) {
+        eventCountBySegment(i) should be < eventCountBySegment(i + 1)
+      }
+
+      val firstToLastRatio = eventCountBySegment.last.toDouble / eventCountBySegment.head.toDouble
+      firstToLastRatio shouldBe 10.0 +- 5.0
+    }
+
+    "generate activities with sinusoidal rate function" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "duration": "1m",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": 1
+                  },
+                  "activity": {
+                    "frequency": {
+                      "function": "sinusoidal",
+                      "base": "10/s",
+                      "amplitude": "10/s",
+                      "period": "20s",
+                      "shift": "0s"
+                    },
+                    "duration": "0s",
+                    "event": {
+                      "frequency": "0/s",
+                      "dataSize": "10B"
+                    }
+                  },
+                  "random": {
+                    "seed": 12345
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+      val generator = SimulationGenerator(settings)
+
+      val events = generator.events().toSeq
+
+      events.size should be > 600
+
+      // check activity density over time by dividing into 30 equal parts (2s each)
+      val timeSegments = 30
+      val segmentDuration = 60.0 / timeSegments
+      val eventCountsBySegment = (0 until timeSegments).map { i =>
+        val segmentStart = i * segmentDuration
+        val segmentEnd = segmentStart + segmentDuration
+        events.count(event => event.time.value >= segmentStart && event.time.value < segmentEnd)
+      }
+
+      // for sinusoidal with period of 20s and no shift we expect:
+      // - highest density at 5s, 25s, 45s
+      // - lowest density at 15s, 35s, 55s
+      val highPointSegments = Seq(2, 12, 22)
+      val lowPointSegments = Seq(7, 17, 27)
+
+      highPointSegments.zip(lowPointSegments).foreach { case (highSegment, lowSegment) =>
+        val high = eventCountsBySegment(highSegment)
+        val low = eventCountsBySegment(lowSegment)
+        val diff = (high - low) / segmentDuration
+        high should be > low
+        diff shouldBe 20.0 +- 10.0
+      }
+
+      // check that the pattern repeats
+      val firstPeriodHighCount = eventCountsBySegment(2).toDouble
+      val secondPeriodHighCount = eventCountsBySegment(12).toDouble
+      val thirdPeriodHighCount = eventCountsBySegment(22).toDouble
+
+      // ensure the high points are roughly similar (within 20% of each other)
+      secondPeriodHighCount shouldBe firstPeriodHighCount +- firstPeriodHighCount * 0.2
+      thirdPeriodHighCount shouldBe firstPeriodHighCount +- firstPeriodHighCount * 0.2
+    }
+
+    "map entities to specific slices with skewed distribution" in {
+      val json = """
+        {
+          "stages": [
+            {
+              "duration": "5s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": {
+                      "count": 1000
+                    },
+                    "slices": "100-200",
+                    "sliceDistribution": {
+                      "type": "zipf",
+                      "exponent": 2.0
+                    }
+                  },
+                  "activity": {
+                    "frequency": "100/s",
+                    "duration": "1s",
+                    "event": {
+                      "frequency": "1/s",
+                      "dataSize": "10B"
+                    }
+                  },
+                  "random": {
+                    "seed": 12345
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+      val generator = SimulationGenerator(settings)
+
+      val events = generator.events().toSeq
+
+      events.size should be > 500
+
+      val sliceDistribution = events.map(_.activity.entityId.slice.value).groupBy(identity).view.mapValues(_.size).toMap
+
+      // check that only slices in the configured range (100-200) are used
+      sliceDistribution.keys.forall(slice => slice >= 100 && slice <= 200) shouldBe true
+
+      // check there's a very skewed distribution over slices (for zipf)
+      val sortedCounts = sliceDistribution.values.toSeq.sorted.reverse
+      val top10Percent = sortedCounts.take((sortedCounts.size * 0.1).toInt + 1)
+      val total = sortedCounts.sum
+      val topSum = top10Percent.sum
+      val topPercentage = topSum.toDouble / total
+      sortedCounts.head should be > (sortedCounts.last * 100)
+      topPercentage should be > 0.8
+    }
+
+  }
+}

--- a/src/test/scala/akka/projection/testing/simulation/SimulationJsonFormatSpec.scala
+++ b/src/test/scala/akka/projection/testing/simulation/SimulationJsonFormatSpec.scala
@@ -1,0 +1,594 @@
+/*
+ * Copyright (C) 2020 - 2024 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.testing.simulation
+
+import scala.concurrent.duration._
+
+import akka.projection.testing.simulation.DistributionShape.LogNormal
+import akka.projection.testing.simulation.DistributionShape.Pareto
+import akka.projection.testing.simulation.DistributionShape.Weibull
+import akka.projection.testing.simulation.DistributionShape.Zipf
+import akka.projection.testing.simulation.SamplerSettings.CategoricalSettings
+import akka.projection.testing.simulation.SamplerSettings.CategorySettings
+import akka.projection.testing.simulation.SamplerSettings.CompositeSettings
+import akka.projection.testing.simulation.SamplerSettings.ConstantSettings
+import akka.projection.testing.simulation.SamplerSettings.ExponentialSettings
+import akka.projection.testing.simulation.SamplerSettings.GammaSettings
+import akka.projection.testing.simulation.SamplerSettings.IncrementalSettings
+import akka.projection.testing.simulation.SamplerSettings.LogNormalSettings
+import akka.projection.testing.simulation.SamplerSettings.ParetoSettings
+import akka.projection.testing.simulation.SamplerSettings.UniformSettings
+import akka.projection.testing.simulation.SamplerSettings.WeibullSettings
+import akka.projection.testing.simulation.SamplerSettings.WeightedSamplerSettings
+import akka.projection.testing.simulation.SamplerSettings.ZipfSettings
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import spray.json._
+
+class SimulationJsonFormatSpec extends AnyWordSpec with Matchers {
+
+  import SimulationJsonFormat._
+
+  "SimulationJsonFormat" should {
+
+    "parse basic SimulationSettings" in {
+      val json = """
+        {
+          "name": "Basic Test",
+          "description": "A simple simulation",
+          "stages": [
+            {
+              "name": "Stage 1",
+              "duration": "10s",
+              "generators": [
+                {
+                  "entityId": {
+                    "entity": { "distribution": "uniform", "min": 1, "max": 100 },
+                    "slices": "0-9"
+                  },
+                  "activity": {
+                    "frequency": "10/s",
+                    "duration": "100ms",
+                    "event": {
+                      "frequency": "5/s",
+                      "dataSize": "1kB"
+                    }
+                  }
+                }
+              ]
+            }
+          ],
+          "engine": {
+            "tick": "100ms",
+            "parallelism": 8,
+            "ackPersists": true,
+            "validationTimeout": "30s"
+          }
+        }
+      """.parseJson
+
+      val settings = json.convertTo[SimulationSettings]
+
+      settings.name shouldBe Some("Basic Test")
+      settings.description shouldBe Some("A simple simulation")
+      settings.stages.size shouldBe 1
+      settings.engine shouldBe Some(EngineSettings(Some(100.millis), Some(8), Some(true), Some(30.seconds)))
+
+      val stage = settings.stages.head
+      stage.name shouldBe Some("Stage 1")
+      stage.duration shouldBe 10.seconds
+      stage.delay shouldBe None
+      stage.generators.size shouldBe 1
+
+      val generator = stage.generators.head
+      generator.entityId shouldBe EntityIdSettings(
+        UniformSettings(1, 100),
+        Some(Range.Inclusive(Slice(0), Slice(9))),
+        sliceDistribution = None)
+
+      val activity = generator.activity
+      activity.frequency shouldBe PointProcessSettings.PoissonSettings(
+        RateFunctionSettings.ConstantSettings(RatePerUnit(10, SECONDS)))
+      activity.perSlice.ranges.size shouldBe 1
+      val (sliceRange, perSliceSettings) = activity.perSlice.ranges.head
+      sliceRange shouldBe Range.Default
+
+      perSliceSettings.perEntity.ranges.size shouldBe 1
+      val (entityRange, perEntitySettings) = perSliceSettings.perEntity.ranges.head
+      entityRange shouldBe Range.Default
+
+      perEntitySettings.duration shouldBe ConstantSettings(100.millis)
+      perEntitySettings.event shouldBe EventSettings(
+        PointProcessSettings.PoissonSettings(RateFunctionSettings.ConstantSettings(RatePerUnit(5, SECONDS))),
+        ConstantSettings(DataSize(1, DataUnit.Kilobytes)))
+
+      generator.random shouldBe None
+    }
+
+    "parse nested ActivitySettings" in {
+      val json = """
+        {
+          "entityId": {
+            "entity": {
+              "count": 100
+            },
+            "slices": "0-127"
+          },
+          "activity": {
+            "frequency": "1/s",
+            "perSlice": {
+              "0-9": {
+                 "perEntity": {
+                   "1-10": {
+                     "duration": "1s",
+                     "event": { "frequency": "10/s", "dataSize": "100B" }
+                   },
+                   "11-20": {
+                     "duration": "2s",
+                     "event": { "frequency": "5/s", "dataSize": "200B" }
+                   },
+                   "*": {
+                     "duration": "500ms",
+                     "event": { "frequency": "2/s", "dataSize": "50B" }
+                   }
+                 }
+              },
+              "*": {
+                 "duration": "100ms",
+                 "event": { "frequency": "1/s", "dataSize": "10B" }
+              }
+            }
+          }
+        }
+       """.parseJson
+
+      val settings = json.convertTo[GeneratorSettings]
+
+      settings.activity.perSlice.ranges should have size 2
+      val slices_0_9 = settings.activity.perSlice.get(Slice(5)).get
+      val slicesDefault = settings.activity.perSlice.get(Slice(100)).get
+
+      slices_0_9.perEntity.ranges should have size 3
+      val slices_0_9_entities_1_10 = slices_0_9.perEntity.get(5).get
+      val slices_0_9_entities_11_20 = slices_0_9.perEntity.get(15).get
+      val slices_0_9_entitiesDefault = slices_0_9.perEntity.get(25).get
+
+      slices_0_9_entities_1_10 shouldBe ActivitySettings.PerEntitySettings(
+        ConstantSettings(1.second),
+        EventSettings(
+          PointProcessSettings.PoissonSettings(RateFunctionSettings.ConstantSettings(RatePerUnit(10, SECONDS))),
+          ConstantSettings(DataSize(100))))
+
+      slices_0_9_entities_11_20 shouldBe ActivitySettings.PerEntitySettings(
+        ConstantSettings(2.seconds),
+        EventSettings(
+          PointProcessSettings.PoissonSettings(RateFunctionSettings.ConstantSettings(RatePerUnit(5, SECONDS))),
+          ConstantSettings(DataSize(200))))
+
+      slices_0_9_entitiesDefault shouldBe ActivitySettings.PerEntitySettings(
+        ConstantSettings(500.millis),
+        EventSettings(
+          PointProcessSettings.PoissonSettings(RateFunctionSettings.ConstantSettings(RatePerUnit(2, SECONDS))),
+          ConstantSettings(DataSize(50))))
+
+      slicesDefault.perEntity.ranges should have size 1
+      val slicesDefaultEntitiesDefault = slicesDefault.perEntity.get(0).get
+      `slicesDefaultEntitiesDefault` shouldBe ActivitySettings.PerEntitySettings(
+        ConstantSettings(100.millis),
+        EventSettings(
+          PointProcessSettings.PoissonSettings(RateFunctionSettings.ConstantSettings(RatePerUnit(1, SECONDS))),
+          ConstantSettings(DataSize(10))))
+    }
+
+    "parse RateFunction shorthand (constant)" in {
+      val json = """ "50 / min" """.parseJson
+      val rate = json.convertTo[RateFunctionSettings]
+      rate shouldBe RateFunctionSettings.ConstantSettings(RatePerUnit(50, MINUTES))
+    }
+
+    "parse RateFunction object (linear)" in {
+      val json = """
+        {
+          "function": "linear",
+          "initial": "10/s",
+          "target": "100/s"
+        }
+      """.parseJson
+      val rate = json.convertTo[RateFunctionSettings]
+      rate shouldBe RateFunctionSettings.LinearSettings(RatePerUnit(10, SECONDS), RatePerUnit(100, SECONDS))
+    }
+
+    "parse RateFunction object (sinusoidal)" in {
+      val json = """
+        {
+          "function": "sinusoidal",
+          "base": "50/s",
+          "amplitude": "20/s",
+          "period": "60s",
+          "shift": "10s"
+        }
+      """.parseJson
+      val rate = json.convertTo[RateFunctionSettings]
+      rate shouldBe RateFunctionSettings.SinusoidalSettings(
+        RatePerUnit(50, SECONDS),
+        RatePerUnit(20, SECONDS),
+        60.seconds,
+        Some(10.seconds))
+    }
+
+    "parse PointProcess shorthand (constant poisson)" in {
+      val json = """ "100 / s" """.parseJson
+      val points = json.convertTo[PointProcessSettings]
+      points shouldBe PointProcessSettings.PoissonSettings(
+        RateFunctionSettings.ConstantSettings(RatePerUnit(100, SECONDS)))
+    }
+
+    "parse PointProcess object (poisson with linear rate)" in {
+      val json = """
+        {
+          "process": "poisson",
+          "rate": {
+            "function": "linear",
+            "initial": "1/s",
+            "target": "10/s"
+          }
+        }
+      """.parseJson
+      val points = json.convertTo[PointProcessSettings]
+      points shouldBe PointProcessSettings.PoissonSettings(
+        RateFunctionSettings.LinearSettings(RatePerUnit(1, SECONDS), RatePerUnit(10, SECONDS)))
+    }
+
+    "parse PointProcess object (implicit poisson with rate function)" in {
+      val json = """
+        {
+          "function": "linear",
+          "initial": "1/s",
+          "target": "10/s"
+        }
+      """.parseJson
+      val points = json.convertTo[PointProcessSettings]
+      points shouldBe PointProcessSettings.PoissonSettings(
+        RateFunctionSettings.LinearSettings(RatePerUnit(1, SECONDS), RatePerUnit(10, SECONDS)))
+    }
+
+    "parse Sampler shorthand (constant)" in {
+      val jsonInt = """ 123 """.parseJson
+      val samplerInt = jsonInt.convertTo[SamplerSettings[Int]]
+      samplerInt shouldBe ConstantSettings(123)
+
+      val jsonDuration = """ "5s" """.parseJson
+      val samplerDuration = jsonDuration.convertTo[SamplerSettings[FiniteDuration]]
+      samplerDuration shouldBe ConstantSettings(5.seconds)
+
+      val jsonDataSize = """ "2MB" """.parseJson
+      val samplerDataSize = jsonDataSize.convertTo[SamplerSettings[DataSize]]
+      samplerDataSize shouldBe ConstantSettings(DataSize(2, DataUnit.Megabytes))
+    }
+
+    "parse Sampler shorthand (count for uniform)" in {
+      val json = """ { "count": 1000 } """.parseJson
+      val sampler = json.convertTo[SamplerSettings[Int]]
+      sampler shouldBe UniformSettings(1, 1000)
+
+      val jsonStr = """ { "count": "10k" } """.parseJson
+      val samplerStr = jsonStr.convertTo[SamplerSettings[Int]]
+      samplerStr shouldBe UniformSettings(1, 10000)
+
+      a[DeserializationException] should be thrownBy {
+        """ { "count": 100 } """.parseJson.convertTo[SamplerSettings[FiniteDuration]]
+      }
+    }
+
+    "parse Sampler object (uniform)" in {
+      val json = """
+        {
+          "distribution": "uniform",
+          "min": 10,
+          "max": 20
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[Int]]
+      sampler shouldBe UniformSettings(10, 20)
+    }
+
+    "parse Sampler object (zipf)" in {
+      val json = """
+        {
+          "distribution": "zipf",
+          "min": 1,
+          "max": 1000,
+          "exponent": 1.2,
+          "shuffled": true
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[Int]]
+      sampler shouldBe ZipfSettings(1, 1000, 1.2, shuffled = Some(true))
+    }
+
+    "parse Sampler object (exponential)" in {
+      val json = """
+        {
+          "distribution": "exponential",
+          "mean": "10ms",
+          "min": "1ms",
+          "max": "1s"
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[FiniteDuration]]
+      sampler shouldBe ExponentialSettings(10.millis, Some(1.millis), Some(1.second), shuffled = None)
+    }
+
+    "parse Sampler object (weibull)" in {
+      val json = """
+        {
+          "distribution": "weibull",
+          "shape": 1.5,
+          "scale": "500ms",
+          "shuffled": true
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[FiniteDuration]]
+      sampler shouldBe WeibullSettings(1.5, 500.millis, None, None, shuffled = Some(true))
+    }
+
+    "parse Sampler object (gamma)" in {
+      val json = """
+        {
+          "distribution": "gamma",
+          "shape": 2.0,
+          "scale": "1kB"
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[DataSize]]
+      sampler shouldBe GammaSettings(2.0, DataSize(1, DataUnit.Kilobytes), None, None, shuffled = None)
+    }
+
+    "parse Sampler object (log-normal mu/sigma)" in {
+      val json = """
+        {
+          "distribution": "log-normal",
+          "mu": 1.0,
+          "sigma": 0.5,
+          "min": "10ms",
+          "max": "2s"
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[FiniteDuration]]
+      sampler shouldBe LogNormalSettings.MuSigmaSettings(1.0, 0.5, Some(10.millis), Some(2.seconds), shuffled = None)
+    }
+
+    "parse Sampler object (log-normal scale/shape)" in {
+      val json = """
+        {
+          "distribution": "log-normal",
+          "scale": "100ms",
+          "shape": 0.8,
+          "shuffled": true
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[FiniteDuration]]
+      sampler shouldBe LogNormalSettings.ScaleShapeSettings(100.millis, 0.8, None, None, shuffled = Some(true))
+    }
+
+    "parse Sampler object (log-normal mean/stdDev)" in {
+      val json = """
+        {
+          "distribution": "log-normal",
+          "mean": "500B",
+          "stdDev": "100B"
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[DataSize]]
+      sampler shouldBe LogNormalSettings.MeanStdDevSettings(DataSize(500), DataSize(100), None, None, shuffled = None)
+    }
+
+    "parse Sampler object (log-normal median/p95)" in {
+      val json = """
+        {
+          "distribution": "log-normal",
+          "median": "1s",
+          "p95": "10s"
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[FiniteDuration]]
+      sampler shouldBe LogNormalSettings.MedianP95Settings(1.second, 10.seconds, None, None, shuffled = None)
+    }
+
+    "parse Sampler object (pareto scale/shape)" in {
+      val json = """
+        {
+          "distribution": "pareto",
+          "scale": "1kB",
+          "shape": 1.5,
+          "max": "1MB"
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[DataSize]]
+      sampler shouldBe ParetoSettings.ScaleShapeSettings(
+        DataSize(1, DataUnit.Kilobytes),
+        1.5,
+        Some(DataSize(1, DataUnit.Megabytes)),
+        shuffled = None)
+    }
+
+    "parse Sampler object (pareto min/p95)" in {
+      val json = """
+        {
+          "distribution": "pareto",
+          "min": "10ms",
+          "p95": "1s",
+          "shuffled": true
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[FiniteDuration]]
+      sampler shouldBe ParetoSettings.MinP95Settings(10.millis, 1.second, None, shuffled = Some(true))
+    }
+
+    "parse Sampler object (categorical)" in {
+      val json = """
+        {
+          "distribution": "categorical",
+          "categories": [
+            { "value": 10, "weight": 0.5 },
+            { "value": 20, "weight": 0.3 },
+            { "value": 30, "weight": 0.2 }
+          ]
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[Int]]
+      sampler shouldBe CategoricalSettings(
+        Seq(CategorySettings(10, 0.5), CategorySettings(20, 0.3), CategorySettings(30, 0.2)))
+    }
+
+    "parse Sampler object (composite)" in {
+      val json = """
+        {
+          "distribution": "composite",
+          "samplers": [
+            {
+              "sampler": { "distribution": "uniform", "min": 1, "max": 10 },
+              "weight": 1.0
+            },
+            {
+              "sampler": { "distribution": "exponential", "mean": 50 },
+              "weight": 2.0
+            }
+          ]
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[Int]]
+      sampler shouldBe CompositeSettings(
+        Seq(
+          WeightedSamplerSettings(UniformSettings(1, 10), 1.0),
+          WeightedSamplerSettings(ExponentialSettings(50, None, None, shuffled = None), 2.0)))
+    }
+
+    "parse Sampler object (incremental)" in {
+      val json = """
+        {
+          "distribution": "incremental",
+          "start": 100,
+          "step": 5,
+          "limit": 200
+        }
+      """.parseJson
+      val sampler = json.convertTo[SamplerSettings[Int]]
+      sampler shouldBe IncrementalSettings(100, 5, Some(200))
+    }
+
+    "parse DistributionShape" in {
+      """{ "type": "uniform" }""".parseJson.convertTo[DistributionShape] shouldBe DistributionShape.Uniform
+      """{ "type": "zipf", "exponent": 1.1, "shuffled": true }""".parseJson
+        .convertTo[DistributionShape] shouldBe Zipf(1.1, shuffled = Some(true))
+      """{ "type": "exponential", "shuffled": false }""".parseJson
+        .convertTo[DistributionShape] shouldBe DistributionShape.Exponential(shuffled = Some(false))
+      """{ "type": "weibull", "shape": 2.5 }""".parseJson
+        .convertTo[DistributionShape] shouldBe Weibull(2.5, shuffled = None)
+      """{ "type": "gamma", "shape": 3.0, "shuffled": true }""".parseJson
+        .convertTo[DistributionShape] shouldBe DistributionShape.Gamma(3.0, shuffled = Some(true))
+      """{ "type": "log-normal", "shape": 0.7 }""".parseJson
+        .convertTo[DistributionShape] shouldBe LogNormal(0.7, shuffled = None)
+      """{ "type": "pareto", "shape": 1.8 }""".parseJson
+        .convertTo[DistributionShape] shouldBe Pareto(1.8, shuffled = None)
+    }
+
+    "parse Slice Range" in {
+      Range.parse[Slice]("*") shouldBe Range.Default
+      Range.parse[Slice]("10") shouldBe Range.Single(Slice(10))
+      Range.parse[Slice]("100-200") shouldBe Range.Inclusive(Slice(100), Slice(200))
+      Range.parse[Slice]("1,5,10-12") shouldBe Range.Multi(
+        Seq(Range.Single(Slice(1)), Range.Single(Slice(5)), Range.Inclusive(Slice(10), Slice(12))))
+    }
+
+    "parse Int Range" in {
+      Range.parse[Int]("*") shouldBe Range.Default
+      Range.parse[Int]("42") shouldBe Range.Single(42)
+      Range.parse[Int]("1000-2000") shouldBe Range.Inclusive(1000, 2000)
+      Range.parse[Int]("1,5,10-12") shouldBe Range.Multi(Seq(Range.Single(1), Range.Single(5), Range.Inclusive(10, 12)))
+    }
+
+    "parse RangeMap" in {
+      val json = """
+        {
+          "0-9": "low",
+          "10-99": "medium",
+          "*": "high"
+        }
+      """.parseJson
+      val rangeMap = json.convertTo[RangeMap[Slice, String]]
+      rangeMap.ranges should contain theSameElementsAs Seq(
+        Range.Inclusive(Slice(0), Slice(9)) -> "low",
+        Range.Inclusive(Slice(10), Slice(99)) -> "medium",
+        Range.Default -> "high")
+      rangeMap(Slice(5)) shouldBe "low"
+      rangeMap(Slice(50)) shouldBe "medium"
+      rangeMap(Slice(500)) shouldBe "high"
+    }
+
+    "parse RandomSettings" in {
+      val json = """
+        {
+          "algorithm": "XO_RO_SHI_RO_128_PP",
+          "seed": 1234567890
+        }
+      """.parseJson
+      val random = json.convertTo[RandomSettings]
+      random shouldBe RandomSettings(Some("XO_RO_SHI_RO_128_PP"), Some(1234567890L))
+    }
+
+    "write and read back complex SimulationSettings" in {
+      val originalSettings = SimulationSettings(
+        name = Some("Complex Test"),
+        description = Some("Test complex features"),
+        stages = Seq(
+          StageSettings(
+            name = Some("Warmup"),
+            duration = 1.minute,
+            delay = Some(5.seconds),
+            generators = Seq(GeneratorSettings(
+              entityId = EntityIdSettings(
+                entity = ZipfSettings(1, 10000, 1.2, shuffled = Some(true)),
+                slices = Some(Range.Multi(Seq(Range.Inclusive(Slice(0), Slice(99)), Range.Single(Slice(500))))),
+                sliceDistribution = Some(DistributionShape.Exponential(shuffled = Some(true)))),
+              activity = ActivitySettings(
+                frequency = PointProcessSettings.PoissonSettings(RateFunctionSettings
+                  .SinusoidalSettings(RatePerUnit(100, SECONDS), RatePerUnit(50, SECONDS), 30.seconds, None)),
+                perSlice = RangeMap(
+                  Range.Inclusive(Slice(0), Slice(99)) -> ActivitySettings.PerSliceSettings(perEntity = RangeMap(
+                    Range.Inclusive(1, 1000) -> ActivitySettings.PerEntitySettings(
+                      duration = LogNormalSettings.MedianP95Settings(500.millis, 2.seconds),
+                      event = EventSettings(
+                        frequency = PointProcessSettings.PoissonSettings(
+                          RateFunctionSettings.ConstantSettings(RatePerUnit(20, SECONDS))),
+                        dataSize = ParetoSettings.MinP95Settings(
+                          DataSize(100),
+                          DataSize(5, DataUnit.Kilobytes),
+                          max = Some(DataSize(1, DataUnit.Megabytes))))),
+                    Range.Default -> ActivitySettings.PerEntitySettings(
+                      duration = ConstantSettings(100.millis),
+                      event = EventSettings(
+                        frequency = PointProcessSettings.PoissonSettings(
+                          RateFunctionSettings.ConstantSettings(RatePerUnit(5, SECONDS))),
+                        dataSize = ConstantSettings(DataSize(50)))))),
+                  Range.Default -> ActivitySettings.PerSliceSettings(perEntity =
+                    RangeMap(Range.Default -> ActivitySettings.PerEntitySettings(
+                      duration = ConstantSettings(10.millis),
+                      event = EventSettings(
+                        frequency = PointProcessSettings.PoissonSettings(
+                          RateFunctionSettings.ConstantSettings(RatePerUnit(1, SECONDS))),
+                        dataSize = ConstantSettings(DataSize(10)))))))),
+              random = Some(RandomSettings(Some("WELL_44497_B"), Some(98765L))))))),
+        engine = Some(EngineSettings(Some(50.millis), Some(16), Some(false), Some(1.minute))))
+
+      val json = originalSettings.toJson
+      // println(json.prettyPrint)
+      val parsedSettings = json.convertTo[SimulationSettings]
+
+      parsedSettings shouldBe originalSettings
+    }
+
+  }
+}


### PR DESCRIPTION
Extend the current testing with a simulation engine for generating more randomised projection tests.

Supports configuring various distribution samplers and rate functions for different aspects of the test generation. Tests still generated in a similar way, from within the cluster, and by sending a request with json config to trigger initially. Validation is currently still the same (just a simple check that all events were projected).

AI assisted for generating some tests, scaladoc, json format, json schema, and examples.

Was going to possibly extend the entity selection and slice assignment, but what is there should be a good starting point. Can create distributions for sampling entities and then an optional distribution over the slices they'll be assigned to, so we can try to create some different patterns within a slice range.

We also need to test restarting projection behaviour (for rolling updates, projection scaling, or failures). We can probably start with the test failures that are already included.

Will add the config for some actual runs when we test these.